### PR TITLE
Add deployment step to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,8 @@
+class Globals {
+  static boolean userInput = true
+  static boolean didTimeout = false
+}
+
 pipeline {
   agent any
   stages {
@@ -10,6 +15,36 @@ pipeline {
     stage('Test') {
       steps {
         sh 'make test'
+      }
+    }
+
+    stage('Publish stable tag') {
+      when{
+        branch 'master'
+      }
+
+      steps {
+        publishStableTag()
+      }
+    }
+
+    stage('Deploy to staging') {
+      when{
+        branch 'master'
+      }
+
+      steps {
+        deploy('staging')
+      }
+    }
+
+    stage('Deploy to production') {
+      when{
+        branch 'master'
+      }
+
+      steps {
+        deploy('production')
       }
     }
   }
@@ -39,4 +74,55 @@ void setBuildStatus(String message, String state) {
       errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
       statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
   ]);
+}
+
+def deploy(deploy_environment) {
+  if(deployCancelled()) {
+    setBuildStatus("Build successful", "SUCCESS");
+    return
+  }
+
+  echo "${deploy_environment}"
+  try {
+    timeout(time: 5, unit: 'MINUTES') {
+      input "Do you want to deploy to ${deploy_environment}?"
+      // Jenkins does a fetch without tags during setup this means
+      // we need to run git fetch again here before we can checkout stable
+      sh('git fetch')
+      sh('git checkout stable')
+
+      docker.withRegistry(env.AWS_ECS_API_REGISTRY) {
+        sh("eval \$(aws ecr get-login --no-include-email)")
+        def appImage = docker.build(
+          "govwifi/user-signup-api:${deploy_environment}",
+          "--build-arg BUNDLE_INSTALL_CMD='bundle install --without test' ."
+        )
+        appImage.push()
+      }
+    }
+  } catch(err) { // timeout reached or input false
+    def user = err.getCauses()[0].getUser()
+
+    if('SYSTEM' == user.toString()) { // SYSTEM means timeout.
+      Globals.didTimeout = true
+      echo "Release window timed out, to deploy please re-run"
+    } else {
+      Globals.userInput = false
+      echo "Aborted by: [${user}]"
+    }
+  }
+}
+
+def publishStableTag() {
+  sshagent(credentials: ['govwifi-jenkins']) {
+    sh('export GIT_SSH_COMMAND="ssh -oStrictHostKeyChecking=no"')
+    sh("git tag -f stable HEAD")
+    sh("git push git@github.com:alphagov/govwifi-user-signup-api.git --force --tags")
+  }
+}
+
+def deployCancelled() {
+  if(Globals.didTimeout || Globals.userInput == false) {
+    return true
+  }
 }


### PR DESCRIPTION
This adds the ability to push built images from Jenkins up to
the Elastic Container Registry with the correct tags.

Code taken from the govwifi-authentication-api repo