### PR TITLE
Add healthcheck route

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # GovWifi User Signup API
 
 Ruby rewrite of the user signup journeys for GovWifi
+
+## Routes
+
+`GET /healthcheck` - Healthcheck route
+ 
+
+## Running the tests
+
+You can run the tests and linter with the following commands:
+
+```shell
+make test
+make lint
+```
+
+## Serving the app locally
+
+```shell
+make serve
+```
+
+Then access the site at [http://localhost:8080/healthcheck](http://localhost:8080/healthcheck)

--- a/app.rb
+++ b/app.rb
@@ -1,1 +1,7 @@
 require 'sinatra/base'
+
+class App < Sinatra::Base
+  get '/healthcheck' do
+    'Healthy'
+  end
+end

--- a/spec/healthcheck_spec.rb
+++ b/spec/healthcheck_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe App do
+  describe 'visiting /healthcheck' do
+    it 'responds with 200 to a GET' do
+      get '/healthcheck'
+      expect(last_response).to be_ok
+    end
+
+    it 'responds with hello world message' do
+      get '/healthcheck'
+      expect(last_response.body).to eq('Healthy')
+    end
+  end
+end


### PR DESCRIPTION
This is a basic healthcheck to be used as part of the ECS task
definition.