### PR TITLE
Add sentry support and enable better logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'http://rubygems.org'
 ruby File.read('.ruby-version').chomp
 
 gem 'puma'
+gem 'sentry-raven'
 gem 'sinatra'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,11 +3,14 @@ GEM
   specs:
     ast (2.4.0)
     diff-lcs (1.3)
+    faraday (0.15.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     govuk-lint (3.8.0)
       rubocop (~> 0.52.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
+    multipart-post (2.0.0)
     mustermann (1.0.2)
     parallel (1.12.1)
     parser (2.5.1.0)
@@ -55,6 +58,8 @@ GEM
     scss_lint (0.57.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.5)
+    sentry-raven (2.7.4)
+      faraday (>= 0.7.6, < 1.0)
     sinatra (2.0.3)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -71,10 +76,11 @@ DEPENDENCIES
   puma
   rack-test
   rspec
+  sentry-raven
   sinatra
 
 RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/app.rb
+++ b/app.rb
@@ -1,6 +1,10 @@
 require 'sinatra/base'
 
 class App < Sinatra::Base
+  configure :production, :staging, :development do
+    enable :logging
+  end
+
   get '/healthcheck' do
     'Healthy'
   end

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,14 @@
 RACK_ENV = ENV['RACK_ENV'] ||= 'development'
 
+if %w[production staging].include?(RACK_ENV)
+  require 'raven'
+
+  Raven.configure do |config|
+    config.dsn = ENV['SENTRY_DSN']
+  end
+
+  use Raven::Rack
+end
+
 require './app'
 run App


### PR DESCRIPTION
This allows us to centralise our error reporting with the other apps, govwifi-allowed-sites, govwifi-authentication-api

By default Sinatra disables logging outside of development and test this reenables it in staging and production now that the RACK_ENV env var is set.