### PR TITLE
Add endpoint for Amazon SNS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ group :test do
   gem 'govuk-lint'
   gem 'rack-test'
   gem 'rspec'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,11 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
@@ -10,12 +14,14 @@ GEM
       rubocop (~> 0.52.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
+    hashdiff (0.3.7)
     multipart-post (2.0.0)
     mustermann (1.0.2)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
+    public_suffix (3.0.2)
     puma (3.11.4)
     rack (2.0.5)
     rack-protection (2.0.3)
@@ -50,6 +56,7 @@ GEM
     rubocop-rspec (1.19.0)
       rubocop (>= 0.51.0)
     ruby-progressbar (1.9.0)
+    safe_yaml (1.0.4)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -67,6 +74,10 @@ GEM
       tilt (~> 2.0)
     tilt (2.0.8)
     unicode-display_width (1.4.0)
+    webmock (3.4.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -78,6 +89,7 @@ DEPENDENCIES
   rspec
   sentry-raven
   sinatra
+  webmock
 
 RUBY VERSION
    ruby 2.5.1p57

--- a/app.rb
+++ b/app.rb
@@ -1,4 +1,5 @@
 require 'sinatra/base'
+require 'net/http'
 
 class App < Sinatra::Base
   configure :production, :staging, :development do
@@ -7,5 +8,11 @@ class App < Sinatra::Base
 
   get '/healthcheck' do
     'Healthy'
+  end
+
+  post '/user-signup/email-notification' do
+    payload = JSON.parse request.body.read
+
+    Net::HTTP.get(URI(payload['SubscribeURL'])) if payload['Type'] == 'SubscriptionConfirmation'
   end
 end

--- a/spec/email_notification_spec.rb
+++ b/spec/email_notification_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe App do
+  describe 'POSTing a SubscriptionConfirmation to /user-signup/email-notification' do
+    it 'makes a GET request to the SubscribeURL' do
+      stub_request(:any, "www.example.com")
+      post '/user-signup/email-notification', { Type: "SubscriptionConfirmation", SubscribeURL: 'http://www.example.com' }.to_json
+
+      expect(WebMock).to have_requested(:get, "www.example.com")
+    end
+  end
+
+  describe 'POSTing a signup Notification to /user-signup/email-notification' do
+    it 'returns a 200' do
+      # Notification format taken from
+      # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-notifications-examples.html
+      notification = {
+        commonHeaders: {
+          from: [
+            'adrian@govwifi.service.gov.uk'
+          ],
+          to: [
+            'signup@govwifi.service.gov.uk'
+          ]
+        }
+      }
+      post '/user-signup/email-notification', { Type: "Notification", Message: notification.to_json }.to_json
+      expect(last_response).to be_ok
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rack/test'
 require 'rspec'
+require 'webmock/rspec'
 
 ENV['RACK_ENV'] = 'test'
 


### PR DESCRIPTION
It currently responds to SubscriptionConfirmations, and doesn't blow up to Notification messages.

By having this in place we can accept the confirmation to AWS SNS and start implementing a notification handler for incoming signup requests via SES.