### PR TITLE
Add check for the incoming email being authorised to sign up to GovWifi

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -14,5 +14,18 @@ class App < Sinatra::Base
     payload = JSON.parse request.body.read
 
     Net::HTTP.get(URI(payload['SubscribeURL'])) if payload['Type'] == 'SubscriptionConfirmation'
+    signup_user(JSON.parse(payload['Message'])) if payload['Type'] == 'Notification'
+    ""
+  end
+
+private
+
+  def signup_user(ses_notification)
+    from_address = ses_notification['commonHeaders']['from'][0]
+    User.new.generate(email: from_address) if authorised_email_domains_regex.match? from_address
+  end
+
+  def authorised_email_domains_regex
+    Regexp.new(ENV.fetch('AUTHORISED_EMAIL_DOMAINS_REGEX'))
   end
 end


### PR DESCRIPTION
We currerntly only accept email self-signups from emails on a list of valid domain names.  The regex that gets used to check against gets is populated via ENV variable.