### PR TITLE
Add check for the incoming email being authorised to sign up to GovWifi

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -14,5 +14,22 @@ class App < Sinatra::Base
     payload = JSON.parse request.body.read
 
     Net::HTTP.get(URI(payload['SubscribeURL'])) if payload['Type'] == 'SubscriptionConfirmation'
+    signup_user(JSON.parse(payload['Message'])) if payload['Type'] == 'Notification'
+    ''
+  end
+
+private
+
+  def signup_user(ses_notification)
+    from_address = ses_notification['commonHeaders']['from'][0]
+    User.new.generate(email: from_address) if authorised_email_domain?(from_address)
+  end
+
+  def authorised_email_domain?(from_address)
+    authorised_email_domains_regex.match?(from_address)
+  end
+
+  def authorised_email_domains_regex
+    Regexp.new(ENV.fetch('AUTHORISED_EMAIL_DOMAINS_REGEX'))
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,4 @@ services:
       DB_USER: root
       DB_HOSTNAME: db
       RACK_ENV: development
+      AUTHORISED_EMAIL_DOMAINS_REGEX: "\\.gov\\.uk$$"

--- a/spec/email_notification_spec.rb
+++ b/spec/email_notification_spec.rb
@@ -1,29 +1,66 @@
 RSpec.describe App do
+  before { ENV['AUTHORISED_EMAIL_DOMAINS_REGEX'] = '.gov.uk$' }
+
   describe 'POSTing a SubscriptionConfirmation to /user-signup/email-notification' do
     it 'makes a GET request to the SubscribeURL' do
-      stub_request(:any, "www.example.com")
-      post '/user-signup/email-notification', { Type: "SubscriptionConfirmation", SubscribeURL: 'http://www.example.com' }.to_json
+      stub_request(:any, 'www.example.com')
+      post '/user-signup/email-notification', { Type: 'SubscriptionConfirmation', SubscribeURL: 'http://www.example.com' }.to_json
 
-      expect(WebMock).to have_requested(:get, "www.example.com")
+      expect(WebMock).to have_requested(:get, 'www.example.com')
     end
   end
 
   describe 'POSTing a signup Notification to /user-signup/email-notification' do
-    it 'returns a 200' do
+    let(:from_address) { 'dummy@example.com' }
+
+    let(:ses_notification) do
       # Notification format taken from
       # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-notifications-examples.html
-      notification = {
+      {
         commonHeaders: {
           from: [
-            'adrian@govwifi.service.gov.uk'
+            from_address
           ],
           to: [
             'signup@govwifi.service.gov.uk'
           ]
         }
       }
-      post '/user-signup/email-notification', { Type: "Notification", Message: notification.to_json }.to_json
+    end
+
+    def post_notification
+      post '/user-signup/email-notification', {
+        Type: 'Notification',
+        Message: ses_notification.to_json
+      }.to_json
+    end
+
+    it 'returns a 200' do
+      post_notification
       expect(last_response).to be_ok
+    end
+
+    describe 'from an authorised email address' do
+      let(:from_address) { 'adrian@adrian.gov.uk' }
+
+      it 'calls User#generate' do
+        expect_any_instance_of(User).to receive(:generate).with(email: from_address)
+        post_notification
+      end
+
+      it 'returns no sensitive information to SNS' do
+        post_notification
+        expect(last_response.body).to eq('')
+      end
+    end
+
+    describe 'from an unauthorised email address' do
+      let(:from_address) { 'adrian@madetech.com' }
+
+      it 'does not call User#generate' do
+        expect_any_instance_of(User).to_not receive(:generate)
+        post_notification
+      end
     end
   end
 end


### PR DESCRIPTION
We currerntly only accept email self-signups from emails on a list of valid domain names.  The regex that gets used to check against gets is populated via ENV variable.