### PR TITLE
Pull in wordlist from S3 to overwrite the test wordlist

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,6 +91,15 @@ def deploy(deploy_environment) {
       sh('git fetch')
       sh('git checkout stable')
 
+      withAWS(credentials: 'jenkins-read-wordlist-credentials') {
+        s3Download(
+          file: 'tmp/wordlist',
+          bucket: 'govwifi-wordlist',
+          path: 'wordlist-short',
+          force: true
+        )
+      }
+
       docker.withRegistry(env.AWS_ECS_API_REGISTRY) {
         sh("eval \$(aws ecr get-login --no-include-email)")
         def appImage = docker.build(


### PR DESCRIPTION
We store the production wordlist in S3 to keep it secret.