### PR TITLE
Send the signup email via GOV.UK Notify

### DIFF
--- a/spec/email_notification_spec.rb
+++ b/spec/email_notification_spec.rb
@@ -41,11 +41,34 @@ RSpec.describe App do
     end
 
     describe 'from an authorised email address' do
+      let(:notify_email_url) { 'https://api.notifications.service.gov.uk/v2/notifications/email' }
+      let(:notify_api_key) { 'mock_key-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000' }
+      let(:notify_template_id) { '00000000-0000-4321-1234-000000000000' }
+      let!(:notify_stub) { stub_request(:post, notify_email_url).to_return(status: 200, body: {}.to_json) }
       let(:from_address) { 'adrian@adrian.gov.uk' }
+      let(:username) { 'MockUsername' }
+      let(:password) { 'MockPassword' }
 
-      it 'calls User#generate' do
-        expect_any_instance_of(User).to receive(:generate).with(email: from_address)
+      before do
+        ENV['NOTIFY_API_KEY'] = notify_api_key
+        ENV['NOTIFY_USER_SIGNUP_EMAIL_TEMPLATE_ID'] = notify_template_id
+
+        expect_any_instance_of(User).to \
+          receive(:generate).with(email: from_address) \
+          .and_return(username: username, password: password)
+      end
+
+      it 'sends email to Notify with the new credentials' do
         post_notification
+        notify_body = {
+          email_address: from_address,
+          template_id: notify_template_id,
+          personalisation: {
+            username: username,
+            password: password
+          }
+        }
+        expect(notify_stub.with(body: notify_body)).to have_been_requested.times(1)
       end
 
       it 'returns no sensitive information to SNS' do


### PR DESCRIPTION
We send an email to the user that signed up with details of their generated username and password so they can connect to GovWifi.