### PR TITLE
Load the user class from app.rb

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,6 +1,8 @@
 require 'sinatra/base'
 require 'net/http'
 
+require './lib/user.rb'
+
 class App < Sinatra::Base
   configure :production, :staging, :development do
     enable :logging

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,6 @@ DB = Sequel.connect(
 )
 
 require File.expand_path '../../app.rb', __FILE__
-require File.expand_path '../../lib/user.rb', __FILE__
 
 module RSpecMixin
   include Rack::Test::Methods


### PR DESCRIPTION
We don't have any autoloading configured for this app, so we should manually load classes for now.

The tests were working as we were loading the User class as part of the spec_helper which was giving false confidence that the app was working.