### PR TITLE
Fix the format sent through by SES when notifying incoming email

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -24,7 +24,7 @@ class App < Sinatra::Base
 private
 
   def handle_signup_request(ses_notification)
-    from_address = ses_notification['commonHeaders']['from'][0]
+    from_address = ses_notification['mail']['commonHeaders']['from'][0]
     signup_user(email: from_address) if authorised_email_domain?(from_address)
   end
 

--- a/spec/email_notification_spec.rb
+++ b/spec/email_notification_spec.rb
@@ -17,13 +17,11 @@ RSpec.describe App do
       # Notification format taken from
       # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-notifications-examples.html
       {
-        commonHeaders: {
-          from: [
-            from_address
-          ],
-          to: [
-            'signup@govwifi.service.gov.uk'
-          ]
+        mail: {
+          commonHeaders: {
+            from: [from_address],
+            to: ['signup@govwifi.service.gov.uk']
+          }
         }
       }
     end


### PR DESCRIPTION
I made a mistake when copying from the example payload which I found when running end to end tests.