### PR TITLE
Extract the email part of an email address when signing up a user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'http://rubygems.org'
 ruby File.read('.ruby-version').chomp
 
+gem "mail", "~> 2.7"
 gem 'mysql2'
 gem 'notifications-ruby-client', '~> 2.6.0'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,9 @@ GEM
       scss_lint
     hashdiff (0.3.7)
     jwt (2.1.0)
+    mail (2.7.0)
+      mini_mime (>= 0.1.1)
+    mini_mime (1.0.0)
     multipart-post (2.0.0)
     mustermann (1.0.2)
     mysql2 (0.5.1)
@@ -89,6 +92,7 @@ PLATFORMS
 
 DEPENDENCIES
   govuk-lint
+  mail
   mysql2
   notifications-ruby-client (~> 2.6.0)
   puma

--- a/lib/user_signup.rb
+++ b/lib/user_signup.rb
@@ -1,0 +1,39 @@
+require 'mail'
+require 'notifications/client'
+
+class UserSignup
+  def initialize(user_model:)
+    @user_model = user_model
+  end
+
+  def execute(contact:)
+    email_address = Mail::Address.new(contact).address
+
+    return unless authorised_email_domain?(email_address)
+
+    login_details = user_model.generate(email: email_address)
+    send_signup_instructions(email_address, login_details)
+  end
+
+private
+
+  attr_accessor :user_model
+
+  def send_signup_instructions(email_address, login_details)
+    client = Notifications::Client.new(ENV.fetch('NOTIFY_API_KEY'))
+
+    client.send_email(
+      email_address: email_address,
+      template_id: ENV.fetch('NOTIFY_USER_SIGNUP_EMAIL_TEMPLATE_ID'),
+      personalisation: login_details
+    )
+  end
+
+  def authorised_email_domain?(from_address)
+    authorised_email_domains_regex.match?(from_address)
+  end
+
+  def authorised_email_domains_regex
+    Regexp.new(ENV.fetch('AUTHORISED_EMAIL_DOMAINS_REGEX'))
+  end
+end

--- a/spec/email_notification_spec.rb
+++ b/spec/email_notification_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe App do
   end
 
   describe 'POSTing a signup Notification to /user-signup/email-notification' do
-    let(:from_address) { 'dummy@example.com' }
+    let(:from_address) { 'adrian@adrian.gov.uk' }
 
     let(:ses_notification) do
       # Notification format taken from
@@ -26,6 +26,10 @@ RSpec.describe App do
       }
     end
 
+    before do
+      allow_any_instance_of(UserSignup).to receive(:execute)
+    end
+
     def post_notification
       post '/user-signup/email-notification', {
         Type: 'Notification',
@@ -38,50 +42,15 @@ RSpec.describe App do
       expect(last_response).to be_ok
     end
 
-    describe 'from an authorised email address' do
-      let(:notify_email_url) { 'https://api.notifications.service.gov.uk/v2/notifications/email' }
-      let(:notify_api_key) { 'mock_key-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000' }
-      let(:notify_template_id) { '00000000-0000-4321-1234-000000000000' }
-      let!(:notify_stub) { stub_request(:post, notify_email_url).to_return(status: 200, body: {}.to_json) }
-      let(:from_address) { 'adrian@adrian.gov.uk' }
-      let(:username) { 'MockUsername' }
-      let(:password) { 'MockPassword' }
-
-      before do
-        ENV['NOTIFY_API_KEY'] = notify_api_key
-        ENV['NOTIFY_USER_SIGNUP_EMAIL_TEMPLATE_ID'] = notify_template_id
-
-        expect_any_instance_of(User).to \
-          receive(:generate).with(email: from_address) \
-          .and_return(username: username, password: password)
-      end
-
-      it 'sends email to Notify with the new credentials' do
-        post_notification
-        notify_body = {
-          email_address: from_address,
-          template_id: notify_template_id,
-          personalisation: {
-            username: username,
-            password: password
-          }
-        }
-        expect(notify_stub.with(body: notify_body)).to have_been_requested.times(1)
-      end
-
-      it 'returns no sensitive information to SNS' do
-        post_notification
-        expect(last_response.body).to eq('')
-      end
+    it 'calls UserSignup#execute' do
+      expect_any_instance_of(UserSignup).to \
+        receive(:execute).with(contact: from_address)
+      post_notification
     end
 
-    describe 'from an unauthorised email address' do
-      let(:from_address) { 'adrian@madetech.com' }
-
-      it 'does not call User#generate' do
-        expect_any_instance_of(User).to_not receive(:generate)
-        post_notification
-      end
+    it 'returns no sensitive information to SNS' do
+      post_notification
+      expect(last_response.body).to eq('')
     end
   end
 end

--- a/spec/user_signup_spec.rb
+++ b/spec/user_signup_spec.rb
@@ -1,0 +1,65 @@
+RSpec.describe UserSignup do
+  let(:user_model) { double(User) }
+  subject { described_class.new(user_model: user_model) }
+
+  describe 'Using an authorised email domain' do
+    let(:notify_email_url) { 'https://api.notifications.service.gov.uk/v2/notifications/email' }
+    let(:notify_email_request) do
+      {
+        email_address: created_contact,
+        template_id: notify_template_id,
+        personalisation: {
+          username: username,
+          password: password,
+        }
+      }
+    end
+    let!(:notify_email_stub) do
+      stub_request(:post, notify_email_url).with(body: notify_email_request)\
+      .to_return(status: 200, body: {}.to_json)
+    end
+    let(:notify_api_key) { 'dummy_key-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000' }
+
+    before do
+      ENV['NOTIFY_API_KEY'] = notify_api_key
+      ENV['NOTIFY_USER_SIGNUP_EMAIL_TEMPLATE_ID'] = notify_template_id
+
+      expect(user_model).to receive(:generate) \
+        .with(email: created_contact) \
+        .and_return(username: username, password: password)
+    end
+
+    context 'given an email address without a name part' do
+      let(:created_contact) { 'adrian@gov.uk' }
+
+      let(:notify_template_id) { '00000000-1234-4321-1234-000000000000' }
+      let(:username) { 'MockUsername' }
+      let(:password) { 'MockPassword' }
+
+      it 'sends email to Notify with the new credentials' do
+        subject.execute(contact: created_contact)
+        expect(notify_email_stub).to have_been_requested.times(1)
+      end
+    end
+
+    context 'given an email address with a name part' do
+      let(:created_contact) { 'ryan@gov.uk' }
+
+      let(:notify_template_id) { '00000000-6789-9876-6789-000000000000' }
+      let(:username) { 'MockUsername2' }
+      let(:password) { 'MockPassword2' }
+
+      it 'sends email to Notify with the new credentials' do
+        subject.execute(contact: 'Ryan <ryan@gov.uk>')
+        expect(notify_email_stub).to have_been_requested.times(1)
+      end
+    end
+  end
+
+  describe 'Using an unauthorised email domain' do
+    it 'does not call the User#generate' do
+      expect(user_model).not_to receive(:generate)
+      subject.execute(contact: 'Ryan <ryan@example.com>')
+    end
+  end
+end


### PR DESCRIPTION
SES is sending through the from email with the name field as such:

`  adrian <adrian@example.com> `

We want to accept these as valid, and extract the address part by itself.

Also move the logic for this out of the Sinatra method into a use case, as it becomes more complex.