### PR TITLE
Use the contact field to store the email address

### DIFF
--- a/lib/user.rb
+++ b/lib/user.rb
@@ -3,7 +3,7 @@ class User < Sequel::Model(:userdetails)
   WORD_LIST = File.readlines(ENV['WORD_LIST_FILE']).map(&:strip)
 
   def generate(email:)
-    existing_user = User.find(email: email)
+    existing_user = User.find(contact: email)
     return login_details(existing_user) if existing_user
 
     user = create_user(email)
@@ -34,7 +34,7 @@ private
     User.create(
       username: random_username,
       password: password_from_word_list,
-      email: email,
+      contact: email,
       sponsor: email
     )
   end

--- a/spec/lib/user_spec.rb
+++ b/spec/lib/user_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe User do
         expect(username_password_from_db).to eq(user)
       end
 
-      it 'stores the email as both the email and sponsor for the user' do
-        expect(user_from_db.email).to eq(email)
+      it 'stores the email as both the contact and sponsor for the user' do
+        expect(user_from_db.contact).to eq(email)
         expect(user_from_db.sponsor).to eq(email)
       end
     end


### PR DESCRIPTION
This matches up with the existing PHP application, and given we are operating both at the same time we need to be consistent with that.

The email field is unused and NULL for all rows