### PR TITLE
Rename UserSignup to EmailSignup

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,7 +1,7 @@
 require 'sinatra/base'
 require 'net/http'
 
-require './lib/user_signup.rb'
+require './lib/email_signup.rb'
 require './lib/user.rb'
 
 class App < Sinatra::Base
@@ -25,6 +25,7 @@ private
 
   def handle_signup_request(ses_notification)
     from_address = ses_notification['mail']['commonHeaders']['from'][0]
-    UserSignup.new(user_model: User.new).execute(contact: from_address)
+    logger.info("Handling signup request from #{from_address}")
+    EmailSignup.new(user_model: User.new).execute(contact: from_address)
   end
 end

--- a/lib/email_signup.rb
+++ b/lib/email_signup.rb
@@ -1,7 +1,7 @@
 require 'mail'
 require 'notifications/client'
 
-class UserSignup
+class EmailSignup
   def initialize(user_model:)
     @user_model = user_model
   end

--- a/spec/email_notification_spec.rb
+++ b/spec/email_notification_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe App do
     end
 
     before do
-      allow_any_instance_of(UserSignup).to receive(:execute)
+      allow_any_instance_of(EmailSignup).to receive(:execute)
     end
 
     def post_notification
@@ -43,7 +43,7 @@ RSpec.describe App do
     end
 
     it 'calls UserSignup#execute' do
-      expect_any_instance_of(UserSignup).to \
+      expect_any_instance_of(EmailSignup).to \
         receive(:execute).with(contact: from_address)
       post_notification
     end

--- a/spec/email_signup_spec.rb
+++ b/spec/email_signup_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe UserSignup do
+RSpec.describe EmailSignup do
   let(:user_model) { double(User) }
   subject { described_class.new(user_model: user_model) }
 


### PR DESCRIPTION
I will be creating a TextSignup which will have separate behaviour:
  * No requirement to validate the sender
  * We'll be sending an SMS vs an email.

Also add a log event for incoming email requests.  This is useful
for monitoring requests.