### PR TITLE
Add template matcher for SMS messages

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -4,6 +4,7 @@ require 'net/http'
 require './lib/email_signup.rb'
 require './lib/sms_signup.rb'
 require './lib/user.rb'
+require './lib/sms_template_finder.rb'
 
 class App < Sinatra::Base
   configure :production, :staging, :development do

--- a/config/production.yml
+++ b/config/production.yml
@@ -1,0 +1,10 @@
+notify_sms_template_ids:
+  credentials: 3a4b1ca8-7b26-4266-8b5f-e05fdbd11879
+  help_menu: 2598f762-5c2f-4af8-9309-6ab932047010
+  generic_help: 18859b96-297f-47dd-a579-4e543a83eaa8
+  device_help:
+    android: 5536eee6-5390-42ec-bdf5-3fe4b15f0127
+    blackberry: efa0b4cf-54fd-4d07-ac58-40d633b94e66
+    mac: 6ef4ca91-7b88-49eb-9b63-90d39aff3c16
+    iphone: ab535538-dc2e-4410-8b40-50fcc852f8bd
+    windows: 801d5deb-6480-4fc6-91e1-da9f5f290c0b

--- a/config/staging.yml
+++ b/config/staging.yml
@@ -1,0 +1,10 @@
+notify_sms_template_ids:
+  credentials: 24d47eb3-8b02-4eba-aa04-81ffaf4bb1b4
+  help_menu: 512deae1-7ec4-4888-8f2d-7be79e5eb379
+  generic_help: 60985003-1682-45a6-8d8d-e121cadbc234
+  device_help:
+    android: ee81124c-2a92-4b63-a7be-258aedb26ed8
+    blackberry: 57b362d0-9753-4fd9-ada0-bfd643db8eee
+    mac: ec8f83bb-5371-40bf-b777-307a52926fe1
+    iphone: 1dc8b2b5-b2e6-4bce-9aae-ee1e9c7cb650
+    windows: 3b8f158b-22c8-4226-b84b-3ea5085a46d5

--- a/lib/sms_template_finder.rb
+++ b/lib/sms_template_finder.rb
@@ -1,0 +1,33 @@
+class SmsTemplateFinder
+  def execute(message_content:, env:)
+    device_name_matchers.each do |matcher, device_name|
+      return device_instruction_config(env).fetch(device_name) if message_content.match?(matcher)
+    end
+
+    template_name = 'generic_help'
+    template_name = 'credentials' if message_content.match?(/^\s*$/) || message_content.match(/go/i)
+    template_name = 'help_menu' if message_content.match?(/help/i)
+
+    config(env)[template_name]
+  end
+
+private
+
+  def device_instruction_config(env)
+    config(env).fetch('device_help')
+  end
+
+  def device_name_matchers
+    {
+      /1|android|samsung|galaxy|htc|huawei|sony|motorola|lg|nexus/i => 'android',
+      /2|ios|ipad|iphone|ipod/i => 'iphone',
+      /3|mac|OSX|apple/i => 'mac',
+      /4|win|windows/i => 'windows',
+      /5|blackberry/i => 'blackberry',
+    }
+  end
+
+  def config(env)
+    YAML.load_file("config/#{env}.yml")['notify_sms_template_ids']
+  end
+end

--- a/spec/lib/sms_template_finder_spec.rb
+++ b/spec/lib/sms_template_finder_spec.rb
@@ -1,0 +1,67 @@
+describe SmsTemplateFinder do
+  let(:environment) { 'production' }
+
+  def template_for_message(message_content)
+    subject.execute(message_content: message_content, env: environment)
+  end
+
+  context 'Given no message content' do
+    context 'on staging' do
+      let(:environment) { 'staging' }
+
+      it 'returns the credentials template id' do
+        expect(template_for_message('')).to eq('24d47eb3-8b02-4eba-aa04-81ffaf4bb1b4')
+      end
+    end
+
+    context 'on production' do
+      let(:environment) { 'production' }
+
+      it 'returns the credentials template id' do
+        expect(template_for_message('')).to eq('3a4b1ca8-7b26-4266-8b5f-e05fdbd11879')
+        expect(template_for_message(' ')).to eq('3a4b1ca8-7b26-4266-8b5f-e05fdbd11879')
+      end
+    end
+  end
+
+
+  context 'Given there is a Go message' do
+    let(:credentials_template) { '3a4b1ca8-7b26-4266-8b5f-e05fdbd11879' }
+    it 'returns the credentials template id' do
+      expect(template_for_message('go')).to eq(credentials_template)
+      expect(template_for_message('Go')).to eq(credentials_template)
+      expect(template_for_message('GO')).to eq(credentials_template)
+    end
+  end
+
+  context 'Given a help message' do
+    context 'on production' do
+      it 'returns the help menu template id' do
+        expect(template_for_message('help')).to eq('2598f762-5c2f-4af8-9309-6ab932047010')
+        expect(template_for_message('HELP')).to eq('2598f762-5c2f-4af8-9309-6ab932047010')
+      end
+    end
+  end
+
+  context 'Given a message of 4' do
+    let(:windows_template) { '801d5deb-6480-4fc6-91e1-da9f5f290c0b' }
+    it 'returns the device template for Windows' do
+      expect(template_for_message('4')).to eq(windows_template)
+      expect(template_for_message(' 4')).to eq(windows_template)
+      expect(template_for_message('hello 4 steve')).to eq(windows_template)
+    end
+  end
+
+  context 'Given a message of 2' do
+    it 'returns the device template for iPhone' do
+      expect(template_for_message('2')).to eq('ab535538-dc2e-4410-8b40-50fcc852f8bd')
+      expect(template_for_message('iphone')).to eq('ab535538-dc2e-4410-8b40-50fcc852f8bd')
+    end
+  end
+
+  context 'Given no template could be derived' do
+    it 'returns the generic help response' do
+      expect(template_for_message('any unmatched content')).to eq('18859b96-297f-47dd-a579-4e543a83eaa8')
+    end
+  end
+end


### PR DESCRIPTION
We have a number of GOV.UK Notify templates for the SMS messages
depending on what message you send through to the service.

This behaviour of what you get sent has been matched to that of
the PHP app.