### PR TITLE
Allow different sms templates to be used based on message content

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -2,7 +2,7 @@ require 'sinatra/base'
 require 'net/http'
 
 require './lib/email_signup.rb'
-require './lib/sms_signup.rb'
+require './lib/sms_response.rb'
 require './lib/user.rb'
 require './lib/sms_template_finder.rb'
 
@@ -24,7 +24,7 @@ class App < Sinatra::Base
   end
 
   post '/user-signup/sms-notification' do
-    SmsSignup.new(user_model: User.new).execute(contact: params[:source])
+    SmsResponse.new(user_model: User.new).execute(contact: params[:source])
     ''
   end
 

--- a/app.rb
+++ b/app.rb
@@ -24,7 +24,15 @@ class App < Sinatra::Base
   end
 
   post '/user-signup/sms-notification' do
-    SmsResponse.new(user_model: User.new).execute(contact: params[:source])
+    template_finder = SmsTemplateFinder.new(environment: ENV.fetch('RACK_ENV'))
+
+    SmsResponse.new(
+      user_model: User.new,
+      template_finder: template_finder
+    ).execute(
+      contact: params[:source],
+      sms_content: params[:message]
+    )
     ''
   end
 

--- a/lib/sms_response.rb
+++ b/lib/sms_response.rb
@@ -1,25 +1,26 @@
 class SmsResponse
-  def initialize(user_model:)
+  def initialize(user_model:, template_finder:)
     @user_model = user_model
+    @template_finder = template_finder
   end
 
-  def execute(contact:)
+  def execute(contact:, sms_content:)
     phone_number = normalised_phone_number(contact)
     login_details = user_model.generate(contact: phone_number)
     notify_params = { login: login_details[:username], pass: login_details[:password] }
-    send_signup_instructions(phone_number, notify_params)
+    send_signup_instructions(phone_number, notify_params, sms_content)
   end
 
 private
 
-  attr_reader :user_model
+  attr_reader :user_model, :template_finder
 
-  def send_signup_instructions(phone_number, login_details)
+  def send_signup_instructions(phone_number, login_details, sms_content)
     client = Notifications::Client.new(ENV.fetch('NOTIFY_API_KEY'))
 
     client.send_sms(
       phone_number: phone_number,
-      template_id: ENV.fetch('NOTIFY_USER_SIGNUP_SMS_TEMPLATE_ID'),
+      template_id: template_finder.execute(message_content: sms_content),
       personalisation: login_details
     )
   end

--- a/lib/sms_response.rb
+++ b/lib/sms_response.rb
@@ -1,4 +1,4 @@
-class SmsSignup
+class SmsResponse
   def initialize(user_model:)
     @user_model = user_model
   end

--- a/lib/sms_template_finder.rb
+++ b/lib/sms_template_finder.rb
@@ -1,20 +1,26 @@
 class SmsTemplateFinder
-  def execute(message_content:, env:)
+  def initialize(environment:)
+    @environment = environment
+  end
+
+  def execute(message_content:)
     device_name_matchers.each do |matcher, device_name|
-      return device_instruction_config(env).fetch(device_name) if message_content.match?(matcher)
+      return device_instruction_config.fetch(device_name) if message_content.match?(matcher)
     end
 
     template_name = 'generic_help'
     template_name = 'credentials' if message_content.match?(/^\s*$/) || message_content.match(/go/i)
     template_name = 'help_menu' if message_content.match?(/help/i)
 
-    config(env)[template_name]
+    config[template_name]
   end
 
 private
 
-  def device_instruction_config(env)
-    config(env).fetch('device_help')
+  attr_reader :environment
+
+  def device_instruction_config
+    config.fetch('device_help')
   end
 
   def device_name_matchers
@@ -27,7 +33,7 @@ private
     }
   end
 
-  def config(env)
-    YAML.load_file("config/#{env}.yml")['notify_sms_template_ids']
+  def config
+    YAML.load_file("config/#{environment}.yml")['notify_sms_template_ids']
   end
 end

--- a/spec/features/sms_spec.rb
+++ b/spec/features/sms_spec.rb
@@ -3,11 +3,11 @@ describe App do
     let(:from_phone_number) { '07700900000' }
     let(:internationalised_phone_number) { '+447700900000' }
     let(:notify_sms_url) { 'https://api.notifications.service.gov.uk/v2/notifications/sms' }
-    let(:notify_template_id) { '00000000-7777-8888-9999-000000000000' }
+    let(:notify_template_id) { '24d47eb3-8b02-4eba-aa04-81ffaf4bb1b4' }
 
     before do
+      ENV['RACK_ENV'] = 'staging'
       ENV['NOTIFY_API_KEY'] = 'dummy_key-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000'
-      ENV['NOTIFY_USER_SIGNUP_SMS_TEMPLATE_ID'] = notify_template_id
       stub_request(:post, notify_sms_url).to_return(status: 200, body: {}.to_json)
     end
 

--- a/spec/lib/sms_response_spec.rb
+++ b/spec/lib/sms_response_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe SmsSignup do
+RSpec.describe SmsResponse do
   let(:user_model) { instance_double(User) }
   subject { described_class.new(user_model: user_model) }
 

--- a/spec/lib/sms_template_finder_spec.rb
+++ b/spec/lib/sms_template_finder_spec.rb
@@ -1,8 +1,9 @@
 describe SmsTemplateFinder do
   let(:environment) { 'production' }
+  subject { described_class.new(environment: environment) }
 
   def template_for_message(message_content)
-    subject.execute(message_content: message_content, env: environment)
+    subject.execute(message_content: message_content)
   end
 
   context 'Given no message content' do

--- a/spec/sms_notification_spec.rb
+++ b/spec/sms_notification_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe App do
 
       it 'calls SmsResponse#execute' do
         expect_any_instance_of(SmsResponse).to \
-          receive(:execute).with(contact: from_phone_number)
+          receive(:execute).with(contact: from_phone_number, sms_content: 'Go')
         post_sms_notification
       end
     end
@@ -26,8 +26,32 @@ RSpec.describe App do
       let(:from_phone_number) { '07700900001' }
       it 'calls SmsResponse#execute' do
         expect_any_instance_of(SmsResponse).to \
-          receive(:execute).with(contact: from_phone_number)
+          receive(:execute).with(contact: from_phone_number, sms_content: 'Go')
         post_sms_notification
+      end
+    end
+
+    describe 'environment specific template finder' do
+      before do
+        allow_any_instance_of(SmsResponse).to receive(:execute)
+      end
+
+      context 'production' do
+        it 'uses the rack environment variable' do
+          ENV['RACK_ENV'] = 'production'
+
+          expect(SmsTemplateFinder).to receive(:new).with(environment: 'production')
+          post_sms_notification
+        end
+      end
+
+      context 'staging' do
+        it 'uses the rack environment variable' do
+          ENV['RACK_ENV'] = 'staging'
+
+          expect(SmsTemplateFinder).to receive(:new).with(environment: 'staging')
+          post_sms_notification
+        end
       end
     end
   end

--- a/spec/sms_notification_spec.rb
+++ b/spec/sms_notification_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe App do
     end
 
     it 'returns no sensitive information to sms provider' do
-      allow_any_instance_of(SmsSignup).to receive(:execute).and_return 'Sensitive info'
+      allow_any_instance_of(SmsResponse).to receive(:execute).and_return 'Sensitive info'
       post_sms_notification
       expect(last_response.body).to eq('')
     end
@@ -15,8 +15,8 @@ RSpec.describe App do
     describe 'from a phone number' do
       let(:from_phone_number) { '07700900000' }
 
-      it 'calls SmsSignup#execute' do
-        expect_any_instance_of(SmsSignup).to \
+      it 'calls SmsResponse#execute' do
+        expect_any_instance_of(SmsResponse).to \
           receive(:execute).with(contact: from_phone_number)
         post_sms_notification
       end
@@ -24,8 +24,8 @@ RSpec.describe App do
 
     describe 'from a different phone number' do
       let(:from_phone_number) { '07700900001' }
-      it 'calls SmsSignup#execute' do
-        expect_any_instance_of(SmsSignup).to \
+      it 'calls SmsResponse#execute' do
+        expect_any_instance_of(SmsResponse).to \
           receive(:execute).with(contact: from_phone_number)
         post_sms_notification
       end


### PR DESCRIPTION
Previously there was a hardcoded template id, replace this with the result of the template finder.

Template finder selects the correct template based on the SMS message content