### PR TITLE
Add support for specifying a custom sponsor value to User#generate

### DIFF
--- a/lib/user.rb
+++ b/lib/user.rb
@@ -2,11 +2,11 @@ class User < Sequel::Model(:userdetails)
   User.unrestrict_primary_key
   WORD_LIST = File.readlines(ENV['WORD_LIST_FILE']).map(&:strip)
 
-  def generate(contact:)
+  def generate(contact:, sponsor: contact)
     existing_user = User.find(contact: contact)
     return login_details(existing_user) if existing_user
 
-    user = create_user(contact)
+    user = create_user(contact, sponsor)
     login_details(user)
   end
 
@@ -30,12 +30,12 @@ private
     WORD_LIST.sample(3).map(&:capitalize).join
   end
 
-  def create_user(contact)
+  def create_user(contact, sponsor)
     User.create(
       username: random_username,
       password: password_from_word_list,
       contact: contact,
-      sponsor: contact
+      sponsor: sponsor
     )
   end
 

--- a/spec/lib/user_spec.rb
+++ b/spec/lib/user_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe User do
     end
   end
 
+  context 'generate with a sponsor value specified' do
+    let(:user_from_db) { User.first }
+
+    it 'stores the sponsor in the sponsor field' do
+      User.new.generate(contact: 'adrian@example.com', sponsor: 'emile@example.com')
+
+      expect(user_from_db.contact).to eq('adrian@example.com')
+      expect(user_from_db.sponsor).to eq('emile@example.com')
+    end
+  end
+
   context 'avoiding duplicate usernames' do
     before do
       srand(2)


### PR DESCRIPTION
When a sponsor signs up a user we store the sponsors contact details.

When a user self-signs up we use the users contact details as the
sponsor.

This behaviour matches the existing PHP code, and given both systems
will be running concurrently we need to preserve this behaviour.