### PR TITLE
Add SponsorUsers UseCase

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -3,6 +3,7 @@ require 'net/http'
 
 require './lib/email_signup.rb'
 require './lib/sms_response.rb'
+require './lib/sponsor_users.rb'
 require './lib/user.rb'
 require './lib/sms_template_finder.rb'
 

--- a/config/production.yml
+++ b/config/production.yml
@@ -8,3 +8,10 @@ notify_sms_template_ids:
     mac: 6ef4ca91-7b88-49eb-9b63-90d39aff3c16
     iphone: ab535538-dc2e-4410-8b40-50fcc852f8bd
     windows: 801d5deb-6480-4fc6-91e1-da9f5f290c0b
+
+notify_email_template_ids:
+  sponsored_credentials: fd536b81-bdd7-4b55-98aa-720173718642
+  sponsor_confirmation:
+    plural: 58e8ef4a-ca6b-40cd-81df-ec9c781fed56
+    singular: 30ab6bc5-20bf-45af-b78d-34cacc0027cd
+    failed: efc83658-dcb5-4401-af42-e26b1945c1a9

--- a/config/staging.yml
+++ b/config/staging.yml
@@ -8,3 +8,10 @@ notify_sms_template_ids:
     mac: ec8f83bb-5371-40bf-b777-307a52926fe1
     iphone: 1dc8b2b5-b2e6-4bce-9aae-ee1e9c7cb650
     windows: 3b8f158b-22c8-4226-b84b-3ea5085a46d5
+
+notify_email_template_ids:
+  sponsored_credentials: 4f6bae31-5add-43a9-b0e3-7db43452676e
+  sponsor_confirmation:
+    plural: 856a5726-1099-4236-b67c-23b654e9edbf
+    singular: 079cb5ff-19b7-4a90-b2e8-dad342ca2bf9
+    failed: efabdaea-36cf-4642-b656-2f9a8393ecc2

--- a/lib/email_address.rb
+++ b/lib/email_address.rb
@@ -1,0 +1,9 @@
+class EmailAddress
+  def self.authorised_email_domain?(from_address)
+    authorised_email_domains_regex.match?(from_address)
+  end
+
+  def self.authorised_email_domains_regex
+    Regexp.new(ENV.fetch('AUTHORISED_EMAIL_DOMAINS_REGEX'))
+  end
+end

--- a/lib/email_signup.rb
+++ b/lib/email_signup.rb
@@ -1,6 +1,8 @@
 require 'mail'
 require 'notifications/client'
 
+require_relative 'email_address'
+
 class EmailSignup
   def initialize(user_model:)
     @user_model = user_model
@@ -9,7 +11,7 @@ class EmailSignup
   def execute(contact:)
     email_address = Mail::Address.new(contact).address
 
-    return unless authorised_email_domain?(email_address)
+    return unless EmailAddress.authorised_email_domain?(email_address)
 
     login_details = user_model.generate(contact: email_address)
     send_signup_instructions(email_address, login_details)
@@ -27,13 +29,5 @@ private
       template_id: ENV.fetch('NOTIFY_USER_SIGNUP_EMAIL_TEMPLATE_ID'),
       personalisation: login_details
     )
-  end
-
-  def authorised_email_domain?(from_address)
-    authorised_email_domains_regex.match?(from_address)
-  end
-
-  def authorised_email_domains_regex
-    Regexp.new(ENV.fetch('AUTHORISED_EMAIL_DOMAINS_REGEX'))
   end
 end

--- a/lib/phone_number.rb
+++ b/lib/phone_number.rb
@@ -1,0 +1,7 @@
+class PhoneNumber
+  def self.internationalise_phone_number(phone_number)
+    phone_number = '44' + phone_number[1..-1] if phone_number[0..1] == '07'
+    phone_number = '+' + phone_number unless phone_number[0] == '+'
+    phone_number
+  end
+end

--- a/lib/sms_response.rb
+++ b/lib/sms_response.rb
@@ -1,3 +1,5 @@
+require_relative 'phone_number'
+
 class SmsResponse
   def initialize(user_model:, template_finder:)
     @user_model = user_model
@@ -5,7 +7,7 @@ class SmsResponse
   end
 
   def execute(contact:, sms_content:)
-    phone_number = normalised_phone_number(contact)
+    phone_number = PhoneNumber.internationalise_phone_number(contact)
     login_details = user_model.generate(contact: phone_number)
     notify_params = { login: login_details[:username], pass: login_details[:password] }
     send_signup_instructions(phone_number, notify_params, sms_content)
@@ -23,11 +25,5 @@ private
       template_id: template_finder.execute(message_content: sms_content),
       personalisation: login_details
     )
-  end
-
-  def normalised_phone_number(phone_number)
-    phone_number = '44' + phone_number[1..-1] if phone_number[0..1] == '07'
-    phone_number = '+' + phone_number unless phone_number[0] == '+'
-    phone_number
   end
 end

--- a/lib/sponsor_users.rb
+++ b/lib/sponsor_users.rb
@@ -1,0 +1,120 @@
+require_relative 'phone_number'
+
+class SponsorUsers
+  def initialize(user_model:)
+    @user_model = user_model
+  end
+
+  def execute(sponsees, sponsor)
+    validate_sponsees(sponsees)
+
+    sponsor_address = Mail::Address.new(sponsor).address
+
+    valid_sponsees = validate_sponsees(sponsees)
+    invite_sponsees(sponsor, sponsor_address, valid_sponsees)
+    send_confirmation_email(sponsor_address, valid_sponsees)
+  end
+
+private
+
+  def invite_sponsees(sponsor, sponsor_address, valid_sponsees)
+    valid_sponsees.each do |sponsee|
+      if valid_email?(sponsee)
+        sponsee_address = Mail::Address.new(sponsee).address
+        sponsor_email(sponsor, sponsor_address, sponsee_address)
+      else
+        sponsee_phone_number = PhoneNumber.internationalise_phone_number(sponsee)
+        sponsor_phone_number(sponsor_address, sponsee_phone_number)
+      end
+    end
+  end
+
+  attr_reader :user_model
+
+  def validate_sponsees(sponsees)
+    valid_sponsees = sponsees.select do |sponsee|
+      valid_email?(sponsee) || valid_phone_number?(sponsee)
+    end
+    valid_sponsees.uniq
+  end
+
+  def notify_client
+    @client ||= Notifications::Client.new(ENV.fetch('NOTIFY_API_KEY'))
+  end
+
+  def sponsor_phone_number(actual_sponsor, sponsee)
+    login_details = user_model.generate(contact: sponsee, sponsor: actual_sponsor)
+    notify_client.send_sms(
+      phone_number: sponsee,
+      template_id: config['notify_sms_template_ids']['credentials'],
+      personalisation: {
+        login: login_details[:username],
+        pass: login_details[:password]
+      }
+    )
+  end
+
+  def sponsor_email(sponsor, sponsor_address, sponsee_address)
+    login_details = user_model.generate(contact: sponsee_address, sponsor: sponsor_address)
+    notify_client.send_email(
+      email_address: sponsee_address,
+      template_id: config['notify_email_template_ids']['sponsored_credentials'],
+      personalisation: login_details.merge(sponsor: sponsor)
+    )
+  end
+
+  def config
+    YAML.load_file("config/#{ENV['RACK_ENV']}.yml")
+  end
+
+  def send_confirmation_email(sponsor, valid_sponsees)
+    return send_sponsor_failed(sponsor) if valid_sponsees.empty?
+    return send_confirmation_singular(sponsor, valid_sponsees) if valid_sponsees.length == 1
+    send_confirmation_plural(sponsor, valid_sponsees)
+  end
+
+  def send_confirmation_plural(sponsor_address, valid_sponsees)
+    notify_client.send_email(
+      email_address: sponsor_address,
+      template_id: sponsor_confirmation_template['plural'],
+      personalisation: {
+        number_of_accounts: valid_sponsees.length,
+        contacts: valid_sponsees.join("\r\n")
+      }
+    )
+  end
+
+  def send_confirmation_singular(sponsor_address, valid_sponsees)
+    notify_client.send_email(
+      email_address: sponsor_address,
+      template_id: sponsor_confirmation_template['singular'],
+      personalisation: {
+        contact: valid_sponsees.first
+      }
+    )
+  end
+
+  def send_sponsor_failed(sponsor_address)
+    notify_client.send_email(
+      email_address: sponsor_address,
+      template_id: sponsor_confirmation_template['failed'],
+      personalisation: {}
+    )
+  end
+
+  def sponsor_confirmation_template
+    config['notify_email_template_ids']['sponsor_confirmation']
+  end
+
+  def valid_email?(sponsee)
+    begin
+      Mail::Address.new(sponsee).address.match?(URI::MailTo::EMAIL_REGEXP)
+    rescue Mail::Field::ParseError
+      false
+    end
+  end
+
+  def valid_phone_number?(sponsee)
+    sponsee.match?(/\A\+?\d{1,15}\Z/)
+  end
+end

--- a/lib/sponsor_users.rb
+++ b/lib/sponsor_users.rb
@@ -1,4 +1,5 @@
 require_relative 'phone_number'
+require_relative 'email_address'
 
 class SponsorUsers
   def initialize(user_model:)
@@ -6,9 +7,9 @@ class SponsorUsers
   end
 
   def execute(sponsees, sponsor)
-    validate_sponsees(sponsees)
-
     sponsor_address = Mail::Address.new(sponsor).address
+
+    return unless EmailAddress.authorised_email_domain?(sponsor_address)
 
     valid_sponsees = validate_sponsees(sponsees)
     invite_sponsees(sponsor, sponsor_address, valid_sponsees)

--- a/spec/lib/sponsor_users_spec.rb
+++ b/spec/lib/sponsor_users_spec.rb
@@ -1,0 +1,174 @@
+describe SponsorUsers do
+  let(:notify_email_url) { 'https://api.notifications.service.gov.uk/v2/notifications/email' }
+  let(:notify_sms_url) { 'https://api.notifications.service.gov.uk/v2/notifications/sms' }
+  let(:username) { 'dummy_username' }
+  let(:password) { 'dummy_password' }
+  let(:environment) { 'production' }
+
+  let(:user_model) { double(generate: { username: username, password: password }) }
+  subject { described_class.new(user_model: user_model) }
+
+  before do
+    ENV['RACK_ENV'] = environment
+    stub_request(:post, notify_email_url).to_return(status: 200, body: {}.to_json)
+    stub_request(:post, notify_sms_url).to_return(status: 200, body: {}.to_json)
+    subject.execute(sponsees, sponsor)
+  end
+
+  context 'Sponsoring a single email address' do
+    let(:sponsor) { 'Chris <chris@example.com>' }
+    let(:sponsees) { ['adrian@example.com'] }
+
+    it 'Calls user_model#generate with the sponsees email' do
+      expect(user_model).to have_received(:generate) \
+        .with(contact: 'adrian@example.com', sponsor: 'chris@example.com')
+    end
+
+    it 'Sends an email to the sponsee_address with the login details' do
+      expect(a_signup_email_request(email: 'adrian@example.com')).to have_been_made.once
+    end
+
+    it 'Sends a single user confirmation email to the sponsor' do
+      body = {
+        email_address: 'chris@example.com',
+        template_id: '30ab6bc5-20bf-45af-b78d-34cacc0027cd',
+        personalisation: {
+          contact: sponsees.first
+        }
+      }
+      expect(a_request(:post, notify_email_url).with(notify_request(body))).to have_been_made.once
+    end
+  end
+
+  context 'Sponsoring a single phone number' do
+    let(:sponsor) { 'Craig <craig@example.com>' }
+    let(:sponsees) { ['+447700900003'] }
+
+    it 'Calls user_model#generate with the sponsees phone number' do
+      expect(user_model).to have_received(:generate) \
+        .with(contact: '+447700900003', sponsor: 'craig@example.com')
+    end
+
+    it 'Sends an sms to the sponsee_address confirming the signup' do
+      expect(a_signup_sms_request(phone_number: '+447700900003')).to have_been_made.once
+    end
+  end
+
+  context 'Sponsoring the same phone number twice' do
+    let(:sponsor) { 'Craig <craig@example.com>' }
+    let(:sponsees) { ['+447700900003', '+447700900003'] }
+
+    it 'Calls user_model#generate once' do
+      expect(user_model).to have_received(:generate) \
+        .with(contact: '+447700900003', sponsor: 'craig@example.com').once
+    end
+  end
+
+  context 'Sponsoring an email address and a phone number' do
+    let(:sponsor) { 'Chloe <chloe@example.com>' }
+    let(:sponsees) { ['Steve <steve@example.com>', '07700900004'] }
+
+    it 'Calls user_model#generate for the email address' do
+      expect(user_model).to have_received(:generate) \
+        .with(contact: 'steve@example.com', sponsor: 'chloe@example.com')
+    end
+
+    it 'Calls the user_model#generate for the phone number' do
+      expect(user_model).to have_received(:generate) \
+        .with(contact: '+447700900004', sponsor: 'chloe@example.com')
+    end
+
+    it 'Sends an email to the sponsee_address with the login details' do
+      expect(a_signup_email_request(email: 'steve@example.com')).to have_been_made.once
+    end
+
+    it 'Sends a sms to the sponsee_address confirming the signup' do
+      expect(a_signup_sms_request(phone_number: '+447700900004')).to have_been_made.once
+    end
+
+    context 'On production' do
+      let(:environment) { 'production' }
+      let(:plural_sponsor_confirmation_template_id) { '58e8ef4a-ca6b-40cd-81df-ec9c781fed56' }
+
+      it 'Sends a multiple user confirmation email to the sponsor' do
+        expect(a_plural_sponsor_confirmation_request).to have_been_made.once
+      end
+    end
+
+    context 'On staging' do
+      let(:environment) { 'staging' }
+      let(:plural_sponsor_confirmation_template_id) { '856a5726-1099-4236-b67c-23b654e9edbf' }
+
+      it 'Sends a multiple user confirmation email to the sponsor' do
+        expect(a_plural_sponsor_confirmation_request).to have_been_made.once
+      end
+    end
+
+    def a_plural_sponsor_confirmation_request
+      body = {
+        email_address: 'chloe@example.com',
+        template_id: plural_sponsor_confirmation_template_id,
+        personalisation: {
+          number_of_accounts: 2,
+          contacts: "Steve <steve@example.com>\r\n07700900004"
+        }
+      }
+      a_request(:post, notify_email_url).with(notify_request(body))
+    end
+  end
+
+  context 'Sponsoring invalid contact details' do
+    let(:sponsor) { 'Cassandra <cassandra@example.com>' }
+    let(:sponsees) { ['Peter', 'Paul', '07invalid700900004', 'Adrian <adrian@example.com> Invalid'] }
+
+    it 'Does not call user_model#generate' do
+      expect(user_model).not_to have_received(:generate)
+    end
+
+
+    it 'Sends a sponsorship failed email to the sponsor' do
+      body = {
+        email_address: 'cassandra@example.com',
+        template_id: 'efc83658-dcb5-4401-af42-e26b1945c1a9',
+        personalisation: {}
+      }
+      expect(a_request(:post, notify_email_url).with(notify_request(body))).to have_been_made.once
+    end
+  end
+
+  def a_signup_sms_request(phone_number:)
+    body = {
+      phone_number: phone_number,
+      template_id: '3a4b1ca8-7b26-4266-8b5f-e05fdbd11879',
+      personalisation: {
+        login: username,
+        pass: password,
+      }
+    }
+
+    a_request(:post, notify_sms_url).with(notify_request(body))
+  end
+
+  def a_signup_email_request(email:)
+    body = {
+      email_address: email,
+      template_id: 'fd536b81-bdd7-4b55-98aa-720173718642',
+      personalisation: {
+        username: username,
+        password: password,
+        sponsor: sponsor
+      }
+    }
+    a_request(:post, notify_email_url).with(notify_request(body))
+  end
+
+  def notify_request(body)
+    {
+      body: body,
+      headers: {
+        'Accept' => '*/*',
+        'Content-Type' => 'application/json',
+      }
+    }
+  end
+end

--- a/spec/lib/sponsor_users_spec.rb
+++ b/spec/lib/sponsor_users_spec.rb
@@ -16,12 +16,12 @@ describe SponsorUsers do
   end
 
   context 'Sponsoring a single email address' do
-    let(:sponsor) { 'Chris <chris@example.com>' }
+    let(:sponsor) { 'Chris <chris@gov.uk>' }
     let(:sponsees) { ['adrian@example.com'] }
 
     it 'Calls user_model#generate with the sponsees email' do
       expect(user_model).to have_received(:generate) \
-        .with(contact: 'adrian@example.com', sponsor: 'chris@example.com')
+        .with(contact: 'adrian@example.com', sponsor: 'chris@gov.uk')
     end
 
     it 'Sends an email to the sponsee_address with the login details' do
@@ -30,7 +30,7 @@ describe SponsorUsers do
 
     it 'Sends a single user confirmation email to the sponsor' do
       body = {
-        email_address: 'chris@example.com',
+        email_address: 'chris@gov.uk',
         template_id: '30ab6bc5-20bf-45af-b78d-34cacc0027cd',
         personalisation: {
           contact: sponsees.first
@@ -41,12 +41,12 @@ describe SponsorUsers do
   end
 
   context 'Sponsoring a single phone number' do
-    let(:sponsor) { 'Craig <craig@example.com>' }
+    let(:sponsor) { 'Craig <craig@gov.uk>' }
     let(:sponsees) { ['+447700900003'] }
 
     it 'Calls user_model#generate with the sponsees phone number' do
       expect(user_model).to have_received(:generate) \
-        .with(contact: '+447700900003', sponsor: 'craig@example.com')
+        .with(contact: '+447700900003', sponsor: 'craig@gov.uk')
     end
 
     it 'Sends an sms to the sponsee_address confirming the signup' do
@@ -55,27 +55,27 @@ describe SponsorUsers do
   end
 
   context 'Sponsoring the same phone number twice' do
-    let(:sponsor) { 'Craig <craig@example.com>' }
+    let(:sponsor) { 'Craig <craig@gov.uk>' }
     let(:sponsees) { ['+447700900003', '+447700900003'] }
 
     it 'Calls user_model#generate once' do
       expect(user_model).to have_received(:generate) \
-        .with(contact: '+447700900003', sponsor: 'craig@example.com').once
+        .with(contact: '+447700900003', sponsor: 'craig@gov.uk').once
     end
   end
 
   context 'Sponsoring an email address and a phone number' do
-    let(:sponsor) { 'Chloe <chloe@example.com>' }
+    let(:sponsor) { 'Chloe <chloe@gov.uk>' }
     let(:sponsees) { ['Steve <steve@example.com>', '07700900004'] }
 
     it 'Calls user_model#generate for the email address' do
       expect(user_model).to have_received(:generate) \
-        .with(contact: 'steve@example.com', sponsor: 'chloe@example.com')
+        .with(contact: 'steve@example.com', sponsor: 'chloe@gov.uk')
     end
 
     it 'Calls the user_model#generate for the phone number' do
       expect(user_model).to have_received(:generate) \
-        .with(contact: '+447700900004', sponsor: 'chloe@example.com')
+        .with(contact: '+447700900004', sponsor: 'chloe@gov.uk')
     end
 
     it 'Sends an email to the sponsee_address with the login details' do
@@ -106,7 +106,7 @@ describe SponsorUsers do
 
     def a_plural_sponsor_confirmation_request
       body = {
-        email_address: 'chloe@example.com',
+        email_address: 'chloe@gov.uk',
         template_id: plural_sponsor_confirmation_template_id,
         personalisation: {
           number_of_accounts: 2,
@@ -118,7 +118,7 @@ describe SponsorUsers do
   end
 
   context 'Sponsoring invalid contact details' do
-    let(:sponsor) { 'Cassandra <cassandra@example.com>' }
+    let(:sponsor) { 'Cassandra <cassandra@gov.uk>' }
     let(:sponsees) { ['Peter', 'Paul', '07invalid700900004', 'Adrian <adrian@example.com> Invalid'] }
 
     it 'Does not call user_model#generate' do
@@ -128,11 +128,20 @@ describe SponsorUsers do
 
     it 'Sends a sponsorship failed email to the sponsor' do
       body = {
-        email_address: 'cassandra@example.com',
+        email_address: 'cassandra@gov.uk',
         template_id: 'efc83658-dcb5-4401-af42-e26b1945c1a9',
         personalisation: {}
       }
       expect(a_request(:post, notify_email_url).with(notify_request(body))).to have_been_made.once
+    end
+  end
+
+  context 'Sponsoring from a non-gov email address' do
+    let(:sponsor) { 'adrian <adrian@fake.uk>' }
+    let(:sponsees) { ['adrian@notgov.uk'] }
+
+    it 'Does not call user_model#generate' do
+      expect(user_model).not_to have_received(:generate)
     end
   end
 


### PR DESCRIPTION
  * Creates accounts for each user
  * Sends a confirmation email to the sponsor
  * Only allows government email addresses to sponsor new users