### PR TITLE
Add extractor for sponsees from an email message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 source 'http://rubygems.org'
 ruby File.read('.ruby-version').chomp
 
-gem "mail", "~> 2.7"
+gem 'mail', '~> 2.7'
 gem 'mysql2'
+gem 'nokogiri', '~> 1.8'
 gem 'notifications-ruby-client', '~> 2.6.0'
 gem 'puma'
 gem 'sentry-raven'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,9 +19,12 @@ GEM
     mail (2.7.0)
       mini_mime (>= 0.1.1)
     mini_mime (1.0.0)
+    mini_portile2 (2.3.0)
     multipart-post (2.0.0)
     mustermann (1.0.2)
     mysql2 (0.5.1)
+    nokogiri (1.8.4)
+      mini_portile2 (~> 2.3.0)
     notifications-ruby-client (2.6.0)
       jwt (>= 1.5, < 3)
     parallel (1.12.1)
@@ -94,6 +97,7 @@ DEPENDENCIES
   govuk-lint
   mail (~> 2.7)
   mysql2
+  nokogiri (~> 1.8)
   notifications-ruby-client (~> 2.6.0)
   puma
   rack-test

--- a/app.rb
+++ b/app.rb
@@ -6,6 +6,7 @@ require './lib/sms_response.rb'
 require './lib/sponsor_users.rb'
 require './lib/user.rb'
 require './lib/sms_template_finder.rb'
+require './lib/email_sponsees_extractor.rb'
 
 class App < Sinatra::Base
   configure :production, :staging, :development do

--- a/lib/email_sponsees_extractor.rb
+++ b/lib/email_sponsees_extractor.rb
@@ -1,0 +1,31 @@
+require 'nokogiri'
+
+class EmailSponseesExtractor
+  def execute(email)
+    mail = Mail.read_from_string(email)
+
+    contacts_from_mail(mail).map(&:strip).reject(&:empty?)
+  end
+
+private
+
+  def contacts_from_mail(mail)
+    if !mail.multipart?
+      lines_from_plain_text(mail.body)
+    elsif mail.text_part
+      lines_from_plain_text(mail.text_part)
+    else
+      lines_from_html(mail)
+    end
+  end
+
+  def lines_from_plain_text(message)
+    message.decoded.lines "\n"
+  end
+
+  def lines_from_html(mail)
+    Nokogiri::HTML(mail.html_part.decoded).xpath("//text()[not(ancestor::style)]").map do |node|
+      node.xpath('normalize-space()')
+    end
+  end
+end

--- a/spec/fixtures/email-sponsor-base64-htmlonly.txt
+++ b/spec/fixtures/email-sponsor-base64-htmlonly.txt
@@ -1,0 +1,74 @@
+Return-Path: <test.sponsor@test.domain.com>
+Received: from test.domain2.com (mail-ve1eur0test.domain3.com [1.1.1.1])
+ by inbound-smtp.test.domain4.com with SMTP id qtl9kqn2nk0elcq323v6oo27k10i4p8eb3ckito1
+ for sponsor@staging.wifi.server.com;
+ Fri, 17 Nov 2017 06:17:47 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of test.domain.com designates 1.1.1.1 as permitted sender) client-ip=1.1.1.1; envelope-from=test.sponsor@test.domain.com; helo=mail-ve1eur0test.domain3.com;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of test.domain.com designates 1.1.1.1 as permitted sender) client-ip=1.1.1.1; envelope-from=test.sponsor@test.domain.com; helo=mail-ve1eur0test.domain3.com;
+ dkim=pass header.i=@test.domain5.com;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFISHlKZ1dLbVFjS2hDV29yVE5nSG9xaHhpdHFxMk9WeE9JcXd6UzBUemZaWjFLbTR2eU82T1VMeFl6eXN2VFdETlFxZytCSVJVUDhaMzFNMG5raXBVRElKNitQM3Fob1F1aVBMVEtoc1JkQ0RpMjVEZ3hCcm54Q21XdDBPa1Y4Si9OVThnVXFUa1BJTlh6U0dZcTIrNVVPaG5DSDZhaXdwanJENmxXTm10VC9OdmFyWTB3OWdrUEFvc0dCVnZJZFU3cWxieUJIdkJhTmtXalRWazg0dnNXek4xVFVkSy9iNnBISlN2WlZTWkV1cjJDNS9EMFZ2ZkRoeGRabjA5THlXL05xUmFnUGdMOFV1elczbVZxc1hNc1FoMkRhdlI2YnA0aWIrWnNsMGM0cE8vS0p5WkhWbVdxU21rbms4RGowakE9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=U3qRsWQjWBOHud/eCVR1hpu4wRWQJsQ6Aqud29V6wgybXTdhwmMKjWo2wYyox1Dpp30bxQaPIFuoRoKUP8mF/DmEevtTqnZBcpsDtvMrheD0TkniQec3gRwErYTnuXnnw2NMBb27nfDcJWhVMGWLxTDkXgAovPrgj9LG9qozNbk=; c=relaxed/simple; s=shh3fegwg5fppqsuzphvschd53n6ihuv; d=amazonses.com; t=1510899468; v=1; bh=0KzkOESEkyH6VX5Tz/Ca9E+hPAPb0kKwGdgLde8fITA=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+ d=test.domain5.com; s=selector1-test-domain-1-com;
+ h=From:Date:Subject:Message-ID:Content-Type:MIME-Version;
+ bh=0KzkOESEkyH6VX5Tz/Ca9E+hPAPb0kKwGdgLde8fITA=;
+ b=Jdpvy8Vl2n55I9jkSLoSzU/E2OZtKcEfX9C/ei+yrnB5hl4MiLkSZBYxj43RgZsjQcWfRbQ2l2OM0O1klI9VieUbfou379yPTlofefmm92IFNiUeuzbii8G6JnvbClhCa894qQ9NlLBE4Trd93XZWXDF8s1LmAG/kOn2ahEOeWg=
+Received: from MM1P123MB1356.GBRP123.test.domain7.com (1.1.1.2) by
+ MM1P123MB1354.GBRP123.test.domain7.com (1.1.1.3) with Microsoft SMTP
+ Server (version=TLS1_2, cipher=TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256) id
+ 1.1.1.4; Fri, 17 Nov 2017 06:17:46 +0000
+Received: from MM1P123MB1356.GBRP123.test.domain7.com ([1.1.1.2]) by
+ MM1P123MB1356.GBRP123.test.domain7.com ([1.1.1.2]) with mapi id
+ 15.20.0239.005; Fri, 17 Nov 2017 06:17:46 +0000
+From: "Test, User (Sponsor)" <test.sponsor@test.domain.com>
+To: "sponsor@staging.wifi.server.com"
+	<sponsor@staging.wifi.server.com>
+Subject: <no subject>
+Thread-Topic: <no subject>
+Thread-Index: AQHTX2vJrTwycQa+7kS6UJ/kevoVOQ==
+Date: Fri, 17 Nov 2017 06:17:46 +0000
+Message-ID: <B48D00A1-8ED5-4543-ABE4-DBB141B15BBD@contoso.com>
+Accept-Language: en-GB, en-US
+Content-Language: en-US
+X-MS-Has-Attach:
+X-MS-TNEF-Correlator:
+authentication-results: spf=none (sender IP is )
+ smtp.mailfrom=test.sponsor@test.domain.com; 
+x-originating-ip: [1.1.1.7]
+x-ms-publictraffictype: Email
+x-microsoft-exchange-diagnostics: 1;MM1P123MB1354;6:k39YfRONQFiJD57JyPQh6ILcALmho8mWNCcEE9IFExBZWWJsRtemYESgvDXig3Vk2/MkVXR++1rHbNR77fuKpHBqYPzT4s0eKE9spNXKWP6cVks/C9Alm5RvG0ujSHj4v0UxXR0yF044PgeoUJEDZIhhbZs9bgY+GGO5sk9l36M1V9v+yBDIE5ARIzaQ+K+OCykZPN/NRHiEN/bSOnigMpOYXuxrFPfGzXJFy7iY0b3z6w3IwIg1i+cD49i/UGF+QmyvEshOA6+Az497PEp3sj7/xLQtvugTA7U4KcOVMQyurNc3XYGEd4XdmSWPaaAev9P6TvpaEJDFw7kg7DATYwUrNQf6P0DO62M2rlXN9io=;5:YIaI2wN9f6pIQFvHYySRSQ/VFtzFoZJ9esDoIu+CZy8mKgb//pCZPbS+pTosvXkFGQggxvMkqvD/xTPGTYO+6hc+IW4AlShTWsbXDOMzgmJcQ6B5WGl9w0MWyoECKPoijj3fpURCZ/e3trOIeqNASs2CxoQb8Ck1+tTipC7DYZY=;24:HeidJvJhcbOAwju/2HfzCYYT2N7SkpS4q1HHvaBy8w6G+Gpo7jq3oePKxv6UhTFjSsLDHbySHiuWWDzlPhljAMzgkEAqop42/4oANPg5/0A=;7:V65ZHX9Ucgtoz8K2AA4HP5P/N/WW+plLsUuTDfO9D3D/wWegnfVuvr47EDRyXxY81ovVxKCRk90owk+17TeKBvuve4TCalZWIlu1I98n/mkeO4Dc7pfev9uLfbqGWIyhBRmG+pX4FoFFZi+pe5AsImKnQoYUbH/BEq3UcuwYqJ7reC4R2JadO1eTlXUIMO6Z45Gy0ThG0YKe1bxyUzyIAbMYRKVOziHomiQXSCWKqfzytidopSPNWlzpBwCtzl2m
+x-ms-exchange-antispam-srfa-diagnostics: SSOS;
+x-ms-office365-filtering-correlation-id: 7eebda6a-f4e2-4e90-70e8-08d52d82ebb8
+x-microsoft-antispam: UriScan:;BCL:0;PCL:0;RULEID:(22001)(4534020)(4602075)(4603075)(7168020)(4627115)(201702281549075)(2017052603199);SRVR:MM1P123MB1354;
+x-ms-traffictypediagnostic: MM1P123MB1354:
+x-microsoft-antispam-prvs: <MM1P123MB13547F5079F7B665D5F18069832F0@MM1P123MB1354.GBRP123.test.domain7.com>
+x-exchange-antispam-report-test: UriScan:(227612066756510)(21748063052155);
+x-exchange-antispam-report-cfa-test: BCL:0;PCL:0;RULEID:(100000700101)(100105000095)(100000701101)(100105300095)(100000702101)(100105100095)(6040450)(2401047)(8121501046)(5005006)(10201501046)(100000703101)(100105400095)(93006095)(93001095)(3231022)(3002001)(6041248)(20161123564025)(20161123562025)(20161123560025)(20161123555025)(201703131423075)(201702281528075)(201703061421075)(201703061406153)(20161123558100)(2016111802025)(6043046)(6072148)(201708071742011)(100000704101)(100105200095)(100000705101)(100105500095);SRVR:MM1P123MB1354;BCL:0;PCL:0;RULEID:(100000800101)(100110000095)(100000801101)(100110300095)(100000802101)(100110100095)(100000803101)(100110400095)(100000804101)(100110200095)(100000805101)(100110500095);SRVR:MM1P123MB1354;
+x-forefront-prvs: 049486C505
+x-forefront-antispam-report: SFV:NSPM;SFS:(10009020)(6009001)(346002)(376002)(189002)(199003)(3660700001)(105586002)(3280700002)(6486002)(77096006)(6916009)(42882006)(4270600006)(2501003)(6506006)(97736004)(2906002)(83716003)(2351001)(8936002)(2900100001)(68736007)(5660300001)(106356001)(74482002)(33656002)(189998001)(14454004)(478600001)(9686003)(6512007)(6306002)(555874004)(551214005)(3846002)(102836003)(6116002)(558084003)(82746002)(86362001)(53936002)(7736002)(316002)(75922002)(101416001)(81166006)(8676002)(81156014)(1730700003)(99286004)(25786009)(36756003)(55236003)(5640700003)(54896002)(66066001)(6436002)(588024002)(50986999)(54356999)(478044003);DIR:OUT;SFP:1101;SCL:1;SRVR:MM1P123MB1354;H:MM1P123MB1356.GBRP123.test.domain7.com;FPR:;SPF:None;PTR:InfoNoRecords;MX:1;A:0;LANG:en;
+received-spf: None (protection.outlook.com: test.domain.com does not
+ designate permitted sender hosts)
+spamdiagnosticoutput: 1:99
+spamdiagnosticmetadata: NSPM
+Content-Type: multipart/alternative;
+	boundary="_000_B48D00A18ED54543ABE4DBB141B15BBDcontosocom_"
+MIME-Version: 1.0
+X-OriginatorOrg: test.domain.com
+X-MS-Exchange-CrossTenant-Network-Message-Id: 7eebda6a-f4e2-4e90-70e8-08d52d82ebb8
+X-MS-Exchange-CrossTenant-originalarrivaltime: 17 Nov 2017 06:17:46.5431
+ (UTC)
+X-MS-Exchange-CrossTenant-fromentityheader: Hosted
+X-MS-Exchange-CrossTenant-id: cbac7005-02c1-43eb-b497-e6492d1b2dd8
+X-MS-Exchange-Transport-CrossTenantHeadersStamped: MM1P123MB1354
+
+--_000_B48D00A18ED54543ABE4DBB141B15BBDcontosocom_
+Content-Type: text/html; charset="utf-8"
+Content-ID: <953670F16F237B40B6D034EF4D05012F@GBRP123.test.domain7.com>
+Content-Transfer-Encoding: base64
+
+PGh0bWwgeG1sbnM6bz0idXJuOnNjaGVtYXMtbWljcm9zb2Z0LWNvbTpvZmZpY2U6b2ZmaWNlIiB4bWxuczp3PSJ1cm46c2NoZW1hcy1taWNyb3NvZnQtY29tOm9mZmljZTp3b3JkIiB4bWxuczptPSJodHRwOi8vc2NoZW1hcy5taWNyb3NvZnQuY29tL29mZmljZS8yMDA0LzEyL29tbWwiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy9UUi9SRUMtaHRtbDQwIj4KPGhlYWQ+CjxtZXRhIGh0dHAtZXF1aXY9IkNvbnRlbnQtVHlwZSIgY29udGVudD0idGV4dC9odG1sOyBjaGFyc2V0PXV0Zi04Ij4KPG1ldGEgbmFtZT0iVGl0bGUiIGNvbnRlbnQ9IiI+CjxtZXRhIG5hbWU9IktleXdvcmRzIiBjb250ZW50PSIiPgo8bWV0YSBuYW1lPSJHZW5lcmF0b3IiIGNvbnRlbnQ9Ik1pY3Jvc29mdCBXb3JkIDE1IChmaWx0ZXJlZCBtZWRpdW0pIj4KPHN0eWxlPjwhLS0KLyogRm9udCBEZWZpbml0aW9ucyAqLwpAZm9udC1mYWNlCgl7Zm9udC1mYW1pbHk6IkNhbWJyaWEgTWF0aCI7CglwYW5vc2UtMToyIDQgNSAzIDUgNCA2IDMgMiA0O30KQGZvbnQtZmFjZQoJe2ZvbnQtZmFtaWx5OkNhbGlicmk7CglwYW5vc2UtMToyIDE1IDUgMiAyIDIgNCAzIDIgNDt9Ci8qIFN0eWxlIERlZmluaXRpb25zICovCnAuTXNvTm9ybWFsLCBsaS5Nc29Ob3JtYWwsIGRpdi5Nc29Ob3JtYWwKCXttYXJnaW46MGluOwoJbWFyZ2luLWJvdHRvbTouMDAwMXB0OwoJZm9udC1zaXplOjEyLjBwdDsKCWZvbnQtZmFtaWx5OiJDYWxpYnJpIixzYW5zLXNlcmlmO30KYTpsaW5rLCBzcGFuLk1zb0h5cGVybGluawoJe21zby1zdHlsZS1wcmlvcml0eTo5OTsKCWNvbG9yOiMwNTYzQzE7Cgl0ZXh0LWRlY29yYXRpb246dW5kZXJsaW5lO30KYTp2aXNpdGVkLCBzcGFuLk1zb0h5cGVybGlua0ZvbGxvd2VkCgl7bXNvLXN0eWxlLXByaW9yaXR5Ojk5OwoJY29sb3I6Izk1NEY3MjsKCXRleHQtZGVjb3JhdGlvbjp1bmRlcmxpbmU7fQpzcGFuLkVtYWlsU3R5bGUxNwoJe21zby1zdHlsZS10eXBlOnBlcnNvbmFsLWNvbXBvc2U7Cglmb250LWZhbWlseToiQ2FsaWJyaSIsc2Fucy1zZXJpZjsKCWNvbG9yOndpbmRvd3RleHQ7fQpzcGFuLm1zb0lucwoJe21zby1zdHlsZS10eXBlOmV4cG9ydC1vbmx5OwoJbXNvLXN0eWxlLW5hbWU6IiI7Cgl0ZXh0LWRlY29yYXRpb246dW5kZXJsaW5lOwoJY29sb3I6dGVhbDt9Ci5Nc29DaHBEZWZhdWx0Cgl7bXNvLXN0eWxlLXR5cGU6ZXhwb3J0LW9ubHk7Cglmb250LWZhbWlseToiQ2FsaWJyaSIsc2Fucy1zZXJpZjt9CkBwYWdlIFdvcmRTZWN0aW9uMQoJe3NpemU6NTk1LjBwdCA4NDIuMHB0OwoJbWFyZ2luOjEuMGluIDEuMGluIDEuMGluIDEuMGluO30KZGl2LldvcmRTZWN0aW9uMQoJe3BhZ2U6V29yZFNlY3Rpb24xO30KLS0+PC9zdHlsZT4KPC9oZWFkPgo8Ym9keSBiZ2NvbG9yPSJ3aGl0ZSIgbGFuZz0iRU4tVVMiIGxpbms9IiMwNTYzQzEiIHZsaW5rPSIjOTU0RjcyIj4KPGRpdiBjbGFzcz0iV29yZFNlY3Rpb24xIj4KPHAgY2xhc3M9Ik1zb05vcm1hbCI+PHNwYW4gbGFuZz0iRU4tR0IiIHN0eWxlPSJmb250LXNpemU6MTEuMHB0Ij5leGFtcGxlLnVzZXIyQGV4YW1wbGUuY28udWs8L3NwYW4+PHNwYW4gbGFuZz0iRU4tR0IiIHN0eWxlPSJmb250LXNpemU6MTEuMHB0Ij48bzpwPjwvbzpwPjwvc3Bhbj48L3A+CjxwIGNsYXNzPSJNc29Ob3JtYWwiPjxzcGFuIGxhbmc9IkVOLUdCIiBzdHlsZT0iZm9udC1zaXplOjExLjBwdCI+MDcxMjM0NTY3ODk8L3NwYW4+PHNwYW4gbGFuZz0iRU4tR0IiIHN0eWxlPSJmb250LXNpemU6MTEuMHB0Ij48bzpwPjwvbzpwPjwvc3Bhbj48L3A+CjwvZGl2Pgo8L2JvZHk+CjwvaHRtbD4K
+
+--_000_B48D00A18ED54543ABE4DBB141B15BBDcontosocom_--

--- a/spec/fixtures/email-sponsor-base64.txt
+++ b/spec/fixtures/email-sponsor-base64.txt
@@ -1,0 +1,80 @@
+Return-Path: <test.sponsor@test.domain.com>
+Received: from test.domain2.com (mail-ve1eur0test.domain3.com [1.1.1.1])
+ by inbound-smtp.test.domain4.com with SMTP id qtl9kqn2nk0elcq323v6oo27k10i4p8eb3ckito1
+ for sponsor@staging.wifi.server.com;
+ Fri, 17 Nov 2017 06:17:47 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of test.domain.com designates 1.1.1.1 as permitted sender) client-ip=1.1.1.1; envelope-from=test.sponsor@test.domain.com; helo=mail-ve1eur0test.domain3.com;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of test.domain.com designates 1.1.1.1 as permitted sender) client-ip=1.1.1.1; envelope-from=test.sponsor@test.domain.com; helo=mail-ve1eur0test.domain3.com;
+ dkim=pass header.i=@test.domain5.com;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFISHlKZ1dLbVFjS2hDV29yVE5nSG9xaHhpdHFxMk9WeE9JcXd6UzBUemZaWjFLbTR2eU82T1VMeFl6eXN2VFdETlFxZytCSVJVUDhaMzFNMG5raXBVRElKNitQM3Fob1F1aVBMVEtoc1JkQ0RpMjVEZ3hCcm54Q21XdDBPa1Y4Si9OVThnVXFUa1BJTlh6U0dZcTIrNVVPaG5DSDZhaXdwanJENmxXTm10VC9OdmFyWTB3OWdrUEFvc0dCVnZJZFU3cWxieUJIdkJhTmtXalRWazg0dnNXek4xVFVkSy9iNnBISlN2WlZTWkV1cjJDNS9EMFZ2ZkRoeGRabjA5THlXL05xUmFnUGdMOFV1elczbVZxc1hNc1FoMkRhdlI2YnA0aWIrWnNsMGM0cE8vS0p5WkhWbVdxU21rbms4RGowakE9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=U3qRsWQjWBOHud/eCVR1hpu4wRWQJsQ6Aqud29V6wgybXTdhwmMKjWo2wYyox1Dpp30bxQaPIFuoRoKUP8mF/DmEevtTqnZBcpsDtvMrheD0TkniQec3gRwErYTnuXnnw2NMBb27nfDcJWhVMGWLxTDkXgAovPrgj9LG9qozNbk=; c=relaxed/simple; s=shh3fegwg5fppqsuzphvschd53n6ihuv; d=amazonses.com; t=1510899468; v=1; bh=0KzkOESEkyH6VX5Tz/Ca9E+hPAPb0kKwGdgLde8fITA=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+ d=test.domain5.com; s=selector1-test-domain-1-com;
+ h=From:Date:Subject:Message-ID:Content-Type:MIME-Version;
+ bh=0KzkOESEkyH6VX5Tz/Ca9E+hPAPb0kKwGdgLde8fITA=;
+ b=Jdpvy8Vl2n55I9jkSLoSzU/E2OZtKcEfX9C/ei+yrnB5hl4MiLkSZBYxj43RgZsjQcWfRbQ2l2OM0O1klI9VieUbfou379yPTlofefmm92IFNiUeuzbii8G6JnvbClhCa894qQ9NlLBE4Trd93XZWXDF8s1LmAG/kOn2ahEOeWg=
+Received: from MM1P123MB1356.GBRP123.test.domain7.com (1.1.1.2) by
+ MM1P123MB1354.GBRP123.test.domain7.com (1.1.1.3) with Microsoft SMTP
+ Server (version=TLS1_2, cipher=TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256) id
+ 1.1.1.4; Fri, 17 Nov 2017 06:17:46 +0000
+Received: from MM1P123MB1356.GBRP123.test.domain7.com ([1.1.1.2]) by
+ MM1P123MB1356.GBRP123.test.domain7.com ([1.1.1.2]) with mapi id
+ 15.20.0239.005; Fri, 17 Nov 2017 06:17:46 +0000
+From: "Test, User (Sponsor)" <test.sponsor@test.domain.com>
+To: "sponsor@staging.wifi.server.com"
+	<sponsor@staging.wifi.server.com>
+Subject: <no subject>
+Thread-Topic: <no subject>
+Thread-Index: AQHTX2vJrTwycQa+7kS6UJ/kevoVOQ==
+Date: Fri, 17 Nov 2017 06:17:46 +0000
+Message-ID: <B48D00A1-8ED5-4543-ABE4-DBB141B15BBD@contoso.com>
+Accept-Language: en-GB, en-US
+Content-Language: en-US
+X-MS-Has-Attach:
+X-MS-TNEF-Correlator:
+authentication-results: spf=none (sender IP is )
+ smtp.mailfrom=test.sponsor@test.domain.com; 
+x-originating-ip: [1.1.1.7]
+x-ms-publictraffictype: Email
+x-microsoft-exchange-diagnostics: 1;MM1P123MB1354;6:k39YfRONQFiJD57JyPQh6ILcALmho8mWNCcEE9IFExBZWWJsRtemYESgvDXig3Vk2/MkVXR++1rHbNR77fuKpHBqYPzT4s0eKE9spNXKWP6cVks/C9Alm5RvG0ujSHj4v0UxXR0yF044PgeoUJEDZIhhbZs9bgY+GGO5sk9l36M1V9v+yBDIE5ARIzaQ+K+OCykZPN/NRHiEN/bSOnigMpOYXuxrFPfGzXJFy7iY0b3z6w3IwIg1i+cD49i/UGF+QmyvEshOA6+Az497PEp3sj7/xLQtvugTA7U4KcOVMQyurNc3XYGEd4XdmSWPaaAev9P6TvpaEJDFw7kg7DATYwUrNQf6P0DO62M2rlXN9io=;5:YIaI2wN9f6pIQFvHYySRSQ/VFtzFoZJ9esDoIu+CZy8mKgb//pCZPbS+pTosvXkFGQggxvMkqvD/xTPGTYO+6hc+IW4AlShTWsbXDOMzgmJcQ6B5WGl9w0MWyoECKPoijj3fpURCZ/e3trOIeqNASs2CxoQb8Ck1+tTipC7DYZY=;24:HeidJvJhcbOAwju/2HfzCYYT2N7SkpS4q1HHvaBy8w6G+Gpo7jq3oePKxv6UhTFjSsLDHbySHiuWWDzlPhljAMzgkEAqop42/4oANPg5/0A=;7:V65ZHX9Ucgtoz8K2AA4HP5P/N/WW+plLsUuTDfO9D3D/wWegnfVuvr47EDRyXxY81ovVxKCRk90owk+17TeKBvuve4TCalZWIlu1I98n/mkeO4Dc7pfev9uLfbqGWIyhBRmG+pX4FoFFZi+pe5AsImKnQoYUbH/BEq3UcuwYqJ7reC4R2JadO1eTlXUIMO6Z45Gy0ThG0YKe1bxyUzyIAbMYRKVOziHomiQXSCWKqfzytidopSPNWlzpBwCtzl2m
+x-ms-exchange-antispam-srfa-diagnostics: SSOS;
+x-ms-office365-filtering-correlation-id: 7eebda6a-f4e2-4e90-70e8-08d52d82ebb8
+x-microsoft-antispam: UriScan:;BCL:0;PCL:0;RULEID:(22001)(4534020)(4602075)(4603075)(7168020)(4627115)(201702281549075)(2017052603199);SRVR:MM1P123MB1354;
+x-ms-traffictypediagnostic: MM1P123MB1354:
+x-microsoft-antispam-prvs: <MM1P123MB13547F5079F7B665D5F18069832F0@MM1P123MB1354.GBRP123.test.domain7.com>
+x-exchange-antispam-report-test: UriScan:(227612066756510)(21748063052155);
+x-exchange-antispam-report-cfa-test: BCL:0;PCL:0;RULEID:(100000700101)(100105000095)(100000701101)(100105300095)(100000702101)(100105100095)(6040450)(2401047)(8121501046)(5005006)(10201501046)(100000703101)(100105400095)(93006095)(93001095)(3231022)(3002001)(6041248)(20161123564025)(20161123562025)(20161123560025)(20161123555025)(201703131423075)(201702281528075)(201703061421075)(201703061406153)(20161123558100)(2016111802025)(6043046)(6072148)(201708071742011)(100000704101)(100105200095)(100000705101)(100105500095);SRVR:MM1P123MB1354;BCL:0;PCL:0;RULEID:(100000800101)(100110000095)(100000801101)(100110300095)(100000802101)(100110100095)(100000803101)(100110400095)(100000804101)(100110200095)(100000805101)(100110500095);SRVR:MM1P123MB1354;
+x-forefront-prvs: 049486C505
+x-forefront-antispam-report: SFV:NSPM;SFS:(10009020)(6009001)(346002)(376002)(189002)(199003)(3660700001)(105586002)(3280700002)(6486002)(77096006)(6916009)(42882006)(4270600006)(2501003)(6506006)(97736004)(2906002)(83716003)(2351001)(8936002)(2900100001)(68736007)(5660300001)(106356001)(74482002)(33656002)(189998001)(14454004)(478600001)(9686003)(6512007)(6306002)(555874004)(551214005)(3846002)(102836003)(6116002)(558084003)(82746002)(86362001)(53936002)(7736002)(316002)(75922002)(101416001)(81166006)(8676002)(81156014)(1730700003)(99286004)(25786009)(36756003)(55236003)(5640700003)(54896002)(66066001)(6436002)(588024002)(50986999)(54356999)(478044003);DIR:OUT;SFP:1101;SCL:1;SRVR:MM1P123MB1354;H:MM1P123MB1356.GBRP123.test.domain7.com;FPR:;SPF:None;PTR:InfoNoRecords;MX:1;A:0;LANG:en;
+received-spf: None (protection.outlook.com: test.domain.com does not
+ designate permitted sender hosts)
+spamdiagnosticoutput: 1:99
+spamdiagnosticmetadata: NSPM
+Content-Type: multipart/alternative;
+	boundary="_000_B48D00A18ED54543ABE4DBB141B15BBDcontosocom_"
+MIME-Version: 1.0
+X-OriginatorOrg: test.domain.com
+X-MS-Exchange-CrossTenant-Network-Message-Id: 7eebda6a-f4e2-4e90-70e8-08d52d82ebb8
+X-MS-Exchange-CrossTenant-originalarrivaltime: 17 Nov 2017 06:17:46.5431
+ (UTC)
+X-MS-Exchange-CrossTenant-fromentityheader: Hosted
+X-MS-Exchange-CrossTenant-id: cbac7005-02c1-43eb-b497-e6492d1b2dd8
+X-MS-Exchange-Transport-CrossTenantHeadersStamped: MM1P123MB1354
+
+--_000_B48D00A18ED54543ABE4DBB141B15BBDcontosocom_
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: base64
+
+ZXhhbXBsZS51c2VyMkBleGFtcGxlLmNvLnVrCjA3MTIzNDU2Nzg5
+
+--_000_B48D00A18ED54543ABE4DBB141B15BBDcontosocom_
+Content-Type: text/html; charset="utf-8"
+Content-ID: <953670F16F237B40B6D034EF4D05012F@GBRP123.test.domain7.com>
+Content-Transfer-Encoding: base64
+
+PGh0bWwgeG1sbnM6bz0idXJuOnNjaGVtYXMtbWljcm9zb2Z0LWNvbTpvZmZpY2U6b2ZmaWNlIiB4bWxuczp3PSJ1cm46c2NoZW1hcy1taWNyb3NvZnQtY29tOm9mZmljZTp3b3JkIiB4bWxuczptPSJodHRwOi8vc2NoZW1hcy5taWNyb3NvZnQuY29tL29mZmljZS8yMDA0LzEyL29tbWwiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy9UUi9SRUMtaHRtbDQwIj4KPGhlYWQ+CjxtZXRhIGh0dHAtZXF1aXY9IkNvbnRlbnQtVHlwZSIgY29udGVudD0idGV4dC9odG1sOyBjaGFyc2V0PXV0Zi04Ij4KPG1ldGEgbmFtZT0iVGl0bGUiIGNvbnRlbnQ9IiI+CjxtZXRhIG5hbWU9IktleXdvcmRzIiBjb250ZW50PSIiPgo8bWV0YSBuYW1lPSJHZW5lcmF0b3IiIGNvbnRlbnQ9Ik1pY3Jvc29mdCBXb3JkIDE1IChmaWx0ZXJlZCBtZWRpdW0pIj4KPHN0eWxlPjwhLS0KLyogRm9udCBEZWZpbml0aW9ucyAqLwpAZm9udC1mYWNlCgl7Zm9udC1mYW1pbHk6IkNhbWJyaWEgTWF0aCI7CglwYW5vc2UtMToyIDQgNSAzIDUgNCA2IDMgMiA0O30KQGZvbnQtZmFjZQoJe2ZvbnQtZmFtaWx5OkNhbGlicmk7CglwYW5vc2UtMToyIDE1IDUgMiAyIDIgNCAzIDIgNDt9Ci8qIFN0eWxlIERlZmluaXRpb25zICovCnAuTXNvTm9ybWFsLCBsaS5Nc29Ob3JtYWwsIGRpdi5Nc29Ob3JtYWwKCXttYXJnaW46MGluOwoJbWFyZ2luLWJvdHRvbTouMDAwMXB0OwoJZm9udC1zaXplOjEyLjBwdDsKCWZvbnQtZmFtaWx5OiJDYWxpYnJpIixzYW5zLXNlcmlmO30KYTpsaW5rLCBzcGFuLk1zb0h5cGVybGluawoJe21zby1zdHlsZS1wcmlvcml0eTo5OTsKCWNvbG9yOiMwNTYzQzE7Cgl0ZXh0LWRlY29yYXRpb246dW5kZXJsaW5lO30KYTp2aXNpdGVkLCBzcGFuLk1zb0h5cGVybGlua0ZvbGxvd2VkCgl7bXNvLXN0eWxlLXByaW9yaXR5Ojk5OwoJY29sb3I6Izk1NEY3MjsKCXRleHQtZGVjb3JhdGlvbjp1bmRlcmxpbmU7fQpzcGFuLkVtYWlsU3R5bGUxNwoJe21zby1zdHlsZS10eXBlOnBlcnNvbmFsLWNvbXBvc2U7Cglmb250LWZhbWlseToiQ2FsaWJyaSIsc2Fucy1zZXJpZjsKCWNvbG9yOndpbmRvd3RleHQ7fQpzcGFuLm1zb0lucwoJe21zby1zdHlsZS10eXBlOmV4cG9ydC1vbmx5OwoJbXNvLXN0eWxlLW5hbWU6IiI7Cgl0ZXh0LWRlY29yYXRpb246dW5kZXJsaW5lOwoJY29sb3I6dGVhbDt9Ci5Nc29DaHBEZWZhdWx0Cgl7bXNvLXN0eWxlLXR5cGU6ZXhwb3J0LW9ubHk7Cglmb250LWZhbWlseToiQ2FsaWJyaSIsc2Fucy1zZXJpZjt9CkBwYWdlIFdvcmRTZWN0aW9uMQoJe3NpemU6NTk1LjBwdCA4NDIuMHB0OwoJbWFyZ2luOjEuMGluIDEuMGluIDEuMGluIDEuMGluO30KZGl2LldvcmRTZWN0aW9uMQoJe3BhZ2U6V29yZFNlY3Rpb24xO30KLS0+PC9zdHlsZT4KPC9oZWFkPgo8Ym9keSBiZ2NvbG9yPSJ3aGl0ZSIgbGFuZz0iRU4tVVMiIGxpbms9IiMwNTYzQzEiIHZsaW5rPSIjOTU0RjcyIj4KPGRpdiBjbGFzcz0iV29yZFNlY3Rpb24xIj4KPHAgY2xhc3M9Ik1zb05vcm1hbCI+PHNwYW4gbGFuZz0iRU4tR0IiIHN0eWxlPSJmb250LXNpemU6MTEuMHB0Ij5leGFtcGxlLnVzZXIyQGV4YW1wbGUuY28udWs8L3NwYW4+PHNwYW4gbGFuZz0iRU4tR0IiIHN0eWxlPSJmb250LXNpemU6MTEuMHB0Ij48bzpwPjwvbzpwPjwvc3Bhbj48L3A+CjxwIGNsYXNzPSJNc29Ob3JtYWwiPjxzcGFuIGxhbmc9IkVOLUdCIiBzdHlsZT0iZm9udC1zaXplOjExLjBwdCI+MDcxMjM0NTY3ODk8L3NwYW4+PHNwYW4gbGFuZz0iRU4tR0IiIHN0eWxlPSJmb250LXNpemU6MTEuMHB0Ij48bzpwPjwvbzpwPjwvc3Bhbj48L3A+CjwvZGl2Pgo8L2JvZHk+CjwvaHRtbD4K
+
+--_000_B48D00A18ED54543ABE4DBB141B15BBDcontosocom_--

--- a/spec/fixtures/email-sponsor-multilevel-multipart.txt
+++ b/spec/fixtures/email-sponsor-multilevel-multipart.txt
@@ -1,0 +1,276 @@
+Return-Path: <Test.User1@example.gov.uk>
+Received: from mail1.mailserver.example.com (mail1.mailserver.example.com [1.1.1.1])
+ by inbound-smtp.eu-west-1.amazonaws.com with SMTP id 6iocf14nls4bn3p9n21vv1t2aurd71g00dgv3jo1
+ for sponsor@wifi.service.gov.uk;
+ Thu, 26 Jan 2017 10:23:21 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: none (spfCheck: 1.1.1.1 is neither permitted nor denied by domain of example.gov.uk) client-ip=1.1.1.1; envelope-from=Test.User1@example.gov.uk; helo=mail1.mailserver.example.com;
+Authentication-Results: amazonses.com;
+ spf=none (spfCheck: 1.1.1.1 is neither permitted nor denied by domain of example.gov.uk) client-ip=1.1.1.1; envelope-from=Test.User1@example.gov.uk; helo=mail1.mailserver.example.com;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFRXJscDI3R1JDdnJzKjTw2bR5UU00cVljNjZwSGpFeHhUczJOK3RQV0VtZExZR2o4d3NMd1Q4ck1jQklBV2thWGtoZWFOYTVtOVc0QTFDM2szOHRJcHIwdVJqUXNEa0tld0pzdnluVGE0NzNvbGZZeE5jQ2kwZ1NEODQxL2gzS2tvZW8wVDJqK0ltZGduRzY2WXI1c00xOGNyNkZFT0F2MVlhV2tRNHRMUjdhYW9rTUJsQ1pRcGtWTkxNakRFdWZ6WWpSQmsyR0diOXJKYkc2TGFNQVlLeVUvdzh4Qit2ZFlFVjFseVFZRDkwelU1SHlScjlPWHdGMVpqcnNiVDEweEpzYXBKNzh1ZGNTajRQaVlCWHZESjVIRStEK0N0TWVqd0xMNDhBbXlmRHc9PQ==
+X-SES-DKIM-SIGNATURE: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple;
+	s=ihchhvubuqswkxyuhssfvqohv7z3u4hn; d=amazonses.com; t=1485426194;
+	h=X-SES-RECEIPT:From:To:Subject:Date:Message-ID:Content-Type:MIME-Version;
+	bh=tIxRAUjE5ujsxBBAAwrIyPxIYyUp7YBkYTqSDgOBlNw=;
+	b=SvHvDogR+YXar07wfsboZKfyiRDHVj+QwpKfJoQL8bDECSVCtr4ZshLZf9ra+6DN
+	Kkj+UV3FoTxk9LEcMvOy/E7xI8d3x0K9IgIllzABJbm2ZdkK6vrJmNKHAd0GskScApS
+	5uMW40IYX2rXLSSjzGcoQAVigOrjU+1e1uNrIYow=
+Return-Path: <Test.User1@example.gov.uk>
+Received: from [1.1.1.2] by server-4.mailserver.example.com id A0/8C-25093-91EC9885; Thu, 26 Jan 2017 10:23:21 +0000
+X-Brightmail-Tracker: H4sIAAAAAAAAA+NgFprCKsWRWlGSWpSXmKPExsVyOEbDQFfiXGe
+  EwYdlahb/Ljxlc2D0aNx2mT2AMYo1My8pvyKBNaPzm3TB6YCKm2eOMTUwnvDuYuTgYBMwljhy
+  JbqLkZNDRMBe4tnzx+wgtrAAh8S+g/OYIOJ6EvvuzQOLswioSpxvPskKYvMKREicObaEBcRmF
+  JCV+NK4mhnEZhYQl7j1CV3Yr4SAiMTDi6fZIGxRiZeP/7FC2PISZ57vBopzAdVPZJQ4sn4y1F
+  BBiZMzn7BMYOSdhWTWLGR1s5DUQRQVSWy6d4IdwtaRWLD7ExuErS2xbOFrZhj7zIHHTJjiuhL
+  TJxyBiitKzF7+ihFi2WpGiStH/wEN5QAbuvS7PEzNlO6H7AsYeVcxqhenFpWlFuma6CUVZaZn
+  lOQmZuboGhqY6eWmFhcnpqfmJCYV6yXn525iBMYQAxDsYOy+7H+IUZKDSUmU96Z2Z4QQX1J+S
+  mVGYnFGfFFpTmrxIUYZDg4lCd7Cs0A5waLU9NSKtMwcYDTDpCU4eJREeDefAUrzFhck5hZnpk
+  OkTjHqcjxYd+YlkxBLXn5eqpQ4bzTIDAGQoozSPLgRsMRyiVFWSpiXEegoIZ6C1KLczBJU+Ve
+  M4hyMSsK8O0FW8WTmlcBtegV0BBPQEReY20GOKElESEk1MKqvNJq85r1WxEZhwWZ2Ca/yxUKa
+  5+2iZDfFSglsWBpmpuM3626R7YYCm4739j57Tu8yvf/XNYD7wP3UXUdPBMUuCl6VW/ftkuLLz
+  /oR+6c9yBVcmc60leHxs+bvv+O/WtfuXHzoTfehv6ElHMe2qrjwLDL4dCL70GmrgOaMpRbCxs
+  U15S2JU5RYijMSDbWYi4oTAVWrxEUnAwAA
+X-Env-Sender: Test.User1@example.gov.uk
+X-Msg-Ref: server-9.mailserver.example.com!1485426199!83501600!1
+X-Originating-IP: [1.1.1.3]
+X-StarScan-Received:
+X-StarScan-Version: 9.1.1; banners=-,-,-
+X-VirusChecked: Checked
+Received: (qmail 11693 invoked from network); 26 Jan 2017 10:23:20 -0000
+Received: from gateway-201.example.gov.uk (HELO mailgate.example.gov.uk) (1.1.1.3)
+  by server-9.mailserver.example.com with DHE-RSA-AES128-SHA encrypted SMTP; 26 Jan 2017 10:23:20 -0000
+From: Test User1 <Test.User1@example.gov.uk>
+To: "sponsor@wifi.service.gov.uk" <sponsor@wifi.service.gov.uk>
+Subject:
+Thread-Index: AdJ3vjOcTgKJcME4RK6uMgGIAs/Rhg==
+Date: Thu, 26 Jan 2017 10:23:14 +0000
+Message-ID: <F6A8AF78123A5C4FBFE47F19KG62C8E6633BD1C0@SDCCMM8032.Poise.ExampleOffice.Local>
+Accept-Language: en-GB, en-US
+Content-Language: en-US
+X-MS-Has-Attach: yes
+X-MS-TNEF-Correlator:
+x-originating-ip: [1.1.1.4]
+Content-Type: multipart/related; 
+    boundary="_004_F6A8AF78123A5C4FBFE47F19DC62C8E6633BD1C0SDCCMM8032Poise_";
+     type="multipart/alternative"
+MIME-Version: 1.0
+
+--_004_F6A8AF78123A5C4FBFE47F19DC62C8E6633BD1C0SDCCMM8032Poise_
+Content-Type: multipart/alternative; 
+    boundary="_000_F6A8AF78123A5C4FBFE47F19DC62C8E6633BD1C0SDCCMM8032Poise_"
+
+--_000_F6A8AF78123A5C4FBFE47F19DC62C8E6633BD1C0SDCCMM8032Poise_
+Content-Type: text/plain; charset="us-ascii"
+Content-Transfer-Encoding: quoted-printable
+
+example.user2@example.co.uk
+
+Test User1
+Policy Officer
+
+Test Unit
+IIPG | Example Office | 3rd Floor | Blahtown | 2 Example Street | London | SW1P=
+ 4DF
+
+Tel (2ASD):               +44 (0) 2012 345 678
+
+Email:            Test.User1@example.gov.uk<mailto:Test.User3@exampl=
+e.gov.uk>
+
+
+[cid:image002.jpg@01CE31D2.EB030560]
+
+
+**********************************************************************
+This email and any files transmitted with it are private and intended
+solely for the use of the individual or entity to whom they are addressed.
+If you have received this email in error please return it to the address
+it came from telling them it is not for you and then delete it from your sy=
+stem.
+This email message has been swept for computer viruses.
+
+**********************************************************************
+
+
+--_000_F6A8AF78123A5C4FBFE47F19DC62C8E6633BD1C0SDCCMM8032Poise_
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: quoted-printable
+
+<html xmlns:v=3D"urn:schemas-microsoft-com:vml" xmlns:o=3D"urn:schemas-micr=
+osoft-com:office:office" xmlns:w=3D"urn:schemas-microsoft-com:office:word" =
+xmlns:m=3D"http://schemas.microsoft.com/office/2004/12/omml" xmlns=3D"http:=
+//www.w3.org/TR/REC-html40">
+<head>
+<meta http-equiv=3D"Content-Type" content=3D"text/html; charset=3Dus-ascii">
+<meta name=3D"Generator" content=3D"Microsoft Word 12 (filtered medium)">
+<!--[if !mso]><style>v\:* {behavior:url(#default#VML);}
+o\:* {behavior:url(#default#VML);}
+w\:* {behavior:url(#default#VML);}
+.shape {behavior:url(#default#VML);}
+</style><![endif]--><style><!--
+/* Font Definitions */
+@font-face
+	{font-family:"Cambria Math";
+	panose-1:2 4 5 3 5 4 6 3 2 4;}
+@font-face
+	{font-family:Calibri;
+	panose-1:2 15 5 2 2 2 4 3 2 4;}
+@font-face
+	{font-family:Tahoma;
+	panose-1:2 11 6 4 3 5 4 4 2 4;}
+@font-face
+	{font-family:"Microsoft Sans Serif";
+	panose-1:2 11 6 4 2 2 2 2 2 4;}
+/* Style Definitions */
+p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{margin:0cm;
+	margin-bottom:.0001pt;
+	font-size:11.0pt;
+	font-family:"Calibri","sans-serif";}
+a:link, span.MsoHyperlink
+	{mso-style-priority:99;
+	color:blue;
+	text-decoration:underline;}
+a:visited, span.MsoHyperlinkFollowed
+	{mso-style-priority:99;
+	color:purple;
+	text-decoration:underline;}
+p.MsoAcetate, li.MsoAcetate, div.MsoAcetate
+	{mso-style-priority:99;
+	mso-style-link:"Balloon Text Char";
+	margin:0cm;
+	margin-bottom:.0001pt;
+	font-size:8.0pt;
+	font-family:"Tahoma","sans-serif";}
+span.EmailStyle17
+	{mso-style-type:personal-compose;
+	font-family:"Arial","sans-serif";
+	color:windowtext;
+	font-weight:normal;
+	font-style:normal;
+	text-decoration:none none;}
+span.BalloonTextChar
+	{mso-style-name:"Balloon Text Char";
+	mso-style-priority:99;
+	mso-style-link:"Balloon Text";
+	font-family:"Tahoma","sans-serif";}
+.MsoChpDefault
+	{mso-style-type:export-only;}
+@page WordSection1
+	{size:612.0pt 792.0pt;
+	margin:72.0pt 72.0pt 72.0pt 72.0pt;}
+div.WordSection1
+	{page:WordSection1;}
+--></style><!--[if gte mso 9]><xml>
+<o:shapedefaults v:ext=3D"edit" spidmax=3D"2050" />
+</xml><![endif]--><!--[if gte mso 9]><xml>
+<o:shapelayout v:ext=3D"edit">
+<o:idmap v:ext=3D"edit" data=3D"1" />
+</o:shapelayout></xml><![endif]-->
+</head>
+<body lang=3D"EN-GB" link=3D"blue" vlink=3D"purple">
+<div class=3D"WordSection1">
+<p class=3D"MsoNormal"><span style=3D"font-size:10.0pt;font-family:&quot;Ar=
+ial&quot;,&quot;sans-serif&quot;">example.user2@example.co.uk<o:p></o=
+:p></span></p>
+<p class=3D"MsoNormal"><span style=3D"font-size:10.0pt;font-family:&quot;Ar=
+ial&quot;,&quot;sans-serif&quot;"><o:p>&nbsp;</o:p></span></p>
+<p class=3D"MsoNormal"><b><span style=3D"font-size:10.0pt;font-family:&quot=
+;Arial&quot;,&quot;sans-serif&quot;;color:black">Test User1<o:p></o:p></spa=
+n></b></p>
+<p class=3D"MsoNormal"><span style=3D"font-size:8.0pt;font-family:&quot;Ari=
+al&quot;,&quot;sans-serif&quot;;color:#595959">Policy Officer</span><span s=
+tyle=3D"font-family:&quot;Arial&quot;,&quot;sans-serif&quot;;color:black"><=
+o:p></o:p></span></p>
+<p class=3D"MsoNormal"><span style=3D"font-family:&quot;Arial&quot;,&quot;s=
+ans-serif&quot;;color:black"><o:p>&nbsp;</o:p></span></p>
+<p class=3D"MsoNormal"><b><span style=3D"font-size:8.0pt;font-family:&quot;=
+Arial&quot;,&quot;sans-serif&quot;;color:black">International Criminality U=
+nit<o:p></o:p></span></b></p>
+<p class=3D"MsoNormal"><span style=3D"font-size:8.0pt;font-family:&quot;Ari=
+al&quot;,&quot;sans-serif&quot;;color:#595959">IIPG | Example Office | 3rd Flo=
+or | Blahtown | 2 Example Street | London | ASD5 123<o:p></o:p></span></p>
+<p class=3D"MsoNormal"><span style=3D"font-size:8.0pt;font-family:&quot;Ari=
+al&quot;,&quot;sans-serif&quot;;color:black"><o:p>&nbsp;</o:p></span></p>
+<p class=3D"MsoNormal"><span style=3D"font-size:8.0pt;font-family:&quot;Ari=
+al&quot;,&quot;sans-serif&quot;;color:#595959">Tel (2ASD):&nbsp;&nbsp;&nbsp;=
+&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &#43;44 (0) 2=
+012 345 678
+<o:p></o:p></span></p>
+<p class=3D"MsoNormal"><span style=3D"font-size:8.0pt;font-family:&quot;Ari=
+al&quot;,&quot;sans-serif&quot;;color:black"><o:p>&nbsp;</o:p></span></p>
+<p class=3D"MsoNormal"><span style=3D"font-size:8.0pt;font-family:&quot;Ari=
+al&quot;,&quot;sans-serif&quot;;color:#595959">Email:&nbsp;&nbsp;&nbsp;&nbs=
+p;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<a href=3D"mailto:Test.User3@example.gov.uk"><span style=3D"color:b=
+lue">Test.User1@example.gov.uk</span></a><o:p></o:p></span></p>
+<p class=3D"MsoNormal"><span style=3D"font-size:8.0pt;font-family:&quot;Ari=
+al&quot;,&quot;sans-serif&quot;;color:#595959"><o:p>&nbsp;</o:p></span></p>
+<p class=3D"MsoNormal"><span style=3D"font-size:8.0pt;font-family:&quot;Ari=
+al&quot;,&quot;sans-serif&quot;;color:#595959"><o:p>&nbsp;</o:p></span></p>
+<p class=3D"MsoNormal"><span style=3D"font-family:&quot;Microsoft Sans Seri=
+f&quot;,&quot;sans-serif&quot;;color:#1F497D"><img border=3D"0" width=3D"14=
+2" height=3D"32" id=3D"Picture_x0020_1" src=3D"cid:image001.jpg@01D277BE.33=
+939FD0" alt=3D"cid:image002.jpg@01CE31D2.EB030560"><o:p></o:p></span></p>
+<p class=3D"MsoNormal"><o:p>&nbsp;</o:p></p>
+</div>
+<p>**********************************************************************<b=
+r />This email and any files transmitted with it are private and intended<b=
+r />solely for the use of the individual or entity to whom they are address=
+ed.<br />If you have received this email in error please return it to the a=
+ddress<br />it came from telling them it is not for you and then delete it =
+from your system.<br />This email message has been swept for computer virus=
+es.</p><p>*****************************************************************=
+*****<br /></p><p>*********************************************************=
+*************</p>=0A</body>
+</html>
+
+--_000_F6A8AF78123A5C4FBFE47F19DC62C8E6633BD1C0SDCCMM8032Poise_--
+
+--_004_F6A8AF78123A5C4FBFE47F19DC62C8E6633BD1C0SDCCMM8032Poise_
+Content-Type: image/jpeg; name="image001.jpg"
+Content-Description: image001.jpg
+Content-Disposition: inline; filename="image001.jpg"; size=1947; 
+    creation-date="Thu, 26 Jan 2017 10:23:14 GMT"; 
+    modification-date="Thu, 26 Jan 2017 10:23:14 GMT"
+Content-ID: <image001.jpg@01D277BE.33939FD0>
+Content-Transfer-Encoding: base64
+
+/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a
+HBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy
+MjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAAgAI4DASIA
+AhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA
+AAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3
+ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm
+p6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA
+AwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx
+BhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK
+U1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3
+uLm6wsPExcbHyMnK0tPU1dbX2Nnu4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD1r4ff
+8iHpH/XI/wDoRqLxL4v/ALB1OGzCW4LxhwZ3ZfNJOAibVOW47+1S/D7/AJEPSP8Arkf/AEI1gfEy
+5DNZRW7D7TbkyNkHAB+6Mgg5yAce1a1/4svV/maVv4kvVmLpHj5bbV9VuvskUCXjeas08z+WFVmQ
+scKeBgDgelek+HtY/tzSEvTGqEsyHYSVbBxuUkAkGvH5La6WCDfPCqyfJHGUlyOCxBxJ04H4+3Fe
+ueFLiKfwzYCNgzRwpHJgY+cKMn8ev41kZmzRXG3usz2vxVtLCW/8nT30l5WidwqGTzAAee+Kb4s1
+54tY8LQ6bqSBbjVUiuEhkU74yrcH2zigDtKK5O9+IOlWl5d28Nnql+lk227nsrRpYoGHUMw6kdwM
+4qW88e6Faf2fslnuzqULTWYtITKZgCOFA789PY5xigDp6K46L4kaXOZYINN1mXUIWKzaelkxniGA
+dzDOADng557Vc/4TvQz4ftNYjlnlju5DFb28cLNPJICQUCddwwc+mKAOlorD0PxTY67c3FpHDd2l
+9bANLaXsJilVT0bHdT6gms7xjrGpR32k+HtFmW31HVXfN0y7vs8KDLuAeC3IAzQB1tFcFqvhrXPD
++lzato3ifVru9tEMz22oyrLDchRllxgbSRnBFY+veN5NavvDFtYtrtpZX8LXM76fb5kk+QFVRsHI
+Uk7sdKAPVaK8oPia41Txb4g8+88R6fZ6daEQrFa7Ui/csXeUEfezymTzgV1jeMdP0rTtIt86hql7
+d2iTRRW9vvnlTaP3jqOFz3yRzQB1dFc3B470KbRbzU5J5bdLOTybmCeJlmikPRCnXccjAGc1JpHj
+DT9VvpLF4L3T7xIvOEGoQGFnjkleueCM8eo9KAIvh9/yIekf9cj/AOhGuU8YWbzazdRs7qzOHDBQ
+flKgDr15454yK6v4ff8AIh6R/wBcj/6Ea09W0W21ZFMmUnQfJKo5HsR3GccfyrWv/Fl6v8zSt/El
+6s8eguJEhgiZz5bmZMSZG8o5UYHY/l1r0jwOkq2dyWTZGpjjUZ4yq84/MflXL6FolvqWo3+lwS+X
+dWgMV3crGQwYtkYDDbyMY9Md69J06wh0vT4bOAuY4hgM5yx5yST65rIzOG1zRbHWvi9Ywanp8V5a
+jRnbbNHuQN5vHXjPJqv4n8K6LoviDwjPpGjW1rI2rosj28IU7drdSO2cV6XRQB5j4V8TaX4J0i80
+PXzLaajbXU7hPJdjeB3LK8eB82QQPwqj4N0u807xH4UW8tXgd7TUJxCy/wCoWSVWVD6HB6e5r1sg
+EgkdKWgDj/DyMPiN4xcoQGFlhiOD+7boe9edxWU9va6Pq811qNhYWupalFcXVnHl7fzJPlcgqflO
+ME44yK90ooA838IR2Oo+NW1Gx1fWdaW2s2ia/udggG5gfLGEUseM8cCtPxrb3ena7ofiu1tZbuLT
+TLFeQwruk8iQYLqvcqRnFdqAAMAYFFAHA618RdI1LR7ix8OSSarq93G0MFtBE+VZhjc5IAQDOTn0
+qvbaK+geIfh9peTJ9js7uOR1Bxu8tc/rmvRQiqSQoBPUgdaWgDza8jkOofE35Hw9jEF+U/N/ozdP
+WqWi6hB4T1+y1TWw8Gn6hoVnDDdtGxSJ41+aNiB8pOQea9WoIBGCMigDyfxNdyeKdLOs6Zp93bad
+Y6tBMb62ixPdRIpDTIhXJ2FuM5yAaz7jSdP8YajDDYa74k1828Lu1wkkUKQbio2FjGPmOAdvbbXt
+FIAB0GKAP//Z
+
+--_004_F6A8AF78123A5C4FBFE47F19DC62C8E6633BD1C0SDCCMM8032Poise_--

--- a/spec/fixtures/email-sponsor-multipart.txt
+++ b/spec/fixtures/email-sponsor-multipart.txt
@@ -1,0 +1,141 @@
+Return-Path: <test.user@example.gov.uk>
+Received: from EUR02-VE1-obe.outbound.protection.example.com (mail-eopbgr20121.outbound.protection.example.com [1.1.1.1])
+ by inbound-smtp.eu-west-1.amazonaws.com with SMTP id 3221aqk3kebv41ppam3j5bfhcq3u2j3s8u0h2bo1
+ for sponsor@wifi.service.gov.uk;
+ Thu, 09 Feb 2017 13:06:10 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of example.gov.uk designates 1.1.1.1 as permitted sender) client-ip=1.1.1.1; envelope-from=test.user@example.gov.uk; helo=mail-eopbgr20121.outbound.protection.example.com;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of example.gov.uk designates 1.1.1.1 as permitted sender) client-ip=1.1.1.1; envelope-from=test.user@example.gov.uk; helo=mail-eopbgr20121.outbound.protection.example.com;
+ dkim=pass header.i=@example.gov.uk;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFHb0ZMajhoOWZjaTJUa1FZMzBYTWN5c092b2FzRG1YN05rVUtlejhxc3RDa1ROb1EzVUhxclZONW8zM0d1SW1uOHFBY0NVdTNyd29oV2NsbDQ2aUVKNEZHRHpZTnNJaC9KRWtBUmx0dFAzZjVMdmNGZ0toOVNNeW11cjhmY3BvWFdXeWc1SUdNNUxneVlkUFdtbmdRdk9nVXpvK0psVTZiYzE0LytkaHVuYURYSFVTcldlMlNaU1hYdjA4Wk9NcUw5Z1pQaERrT1pBZllvNmJmUVRpVVJha3lQN1ZSYk1IUFRiZ0c2Nm9udjdqRzl2OENxWTVjQ3dJNDA5ZGZuNkx6QTZoNk82alZVcXMxMCt3cmNxeHZsWA==
+X-SES-DKIM-SIGNATURE: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple;
+	s=ihchhvubuqgjsxyuhssfvqohv7z3u4hn; d=amazonses.com; t=1486645568;
+	h=X-SES-RECEIPT:From:To:Subject:Date:Message-ID:Content-Type:MIME-Version;
+	bh=YYeVSqIPcNjhmmBJHo+YPRVNVtthVVaqQeaiTb3qhtA=;
+	b=DlvcKBLtj3S1uCDLnCggAzvtwG+wamJiw2VVI9waHRpYkeYKa0WW3VYBELT/Gp83
+	ywsjvcp7r9bP9uioWe5ICzFoTdYVL+8PXNuhmUOy4C3JDQPpXs8mIu18iNnbK2DZ4iF
+	r1LyJf4/9yYo5yQbDPWIy1UkRGif+HxCiftowQcQ=
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=example.gov.uk;
+ s=selector1; h=From:Date:Subject:Message-ID:Content-Type:MIME-Version;
+ bh=HsGIfnuzeSy21AywSasuB5M0eqvcfbjbCJct58JVbQE=;
+ b=hAk6jS+dKOV51/azNmzoklGKpDvLOrjnlt8qicrGsfx7CIAZC6nGO/5Jcf0uYBv9nR1LRM9UtwMlmoLRvUDlWmUrsTsDU907WvUrWtzZv89V4QmLcfRag7aXmflUd2UvF9cnLTE+BV7EyP1e64RnVLD7ao8yKKwDp5qV/n86E44=
+Received: from VI1PR0802MB2255.eurprd08.prod.example.com (1.1.1.2) by
+ VI1PR0802MB2256.eurprd08.prod.example.com (1.1.1.3) with Microsoft SMTP
+ Server (version=TLS1_2, cipher=TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P384) id
+ 1.1.1.4; Thu, 9 Feb 2017 13:06:09 +0000
+Received: from VI1PR0802MB2255.eurprd08.prod.example.com ([1.1.1.2]) by
+ VI1PR0802MB2255.eurprd08.prod.example.com ([1.1.1.2]) with mapi id
+ 15.01.0888.026; Thu, 9 Feb 2017 13:06:08 +0000
+From: Test U <test.user@example.gov.uk>
+To: "sponsor@wifi.service.gov.uk" <sponsor@wifi.service.gov.uk>
+Subject:
+Thread-Index: AdKC1Ua1KLMrNuANQA+ZCItPsI8uRA==
+Date: Thu, 9 Feb 2017 13:06:08 +0000
+Message-ID: <VI1PR0802MB2255937A3640A34E1BBDC8A5AF450@VI1PR0802MB2255.eurprd08.prod.example.com>
+Accept-Language: en-GB, en-US
+Content-Language: en-US
+X-MS-Has-Attach:
+X-MS-TNEF-Correlator:
+authentication-results: spf=none (sender IP is )
+ smtp.mailfrom=test.user@example.gov.uk;
+x-originating-ip: [1.1.1.5]
+x-ms-office365-filtering-correlation-id: 73a82e57-2c97-4c6f-d1a4-08d450ec6a16
+x-microsoft-antispam: UriScan:;BCL:0;PCL:0;RULEID:(22001);SRVR:VI1PR0802MB2256;
+x-microsoft-exchange-diagnostics: 1;VI1PR0802MB2256;7:frY4zjhtxHPL3hEvDbZgmX7ePtkLZcHCfUIf4FzlSabGznyji7wigpUjah3ike1pgwuty05W/JB8VmBJSL6F6h9BtS9AIdkbU85p9PxZ8zfCSEWtL6gP7A6N9aUzs3Ch/0WzaqP9/o2JKGM+92YpA0PCdQeWHwct9oxWStCTa/aqnaX0nLqVFitD3P0QsJpaXMbGqclN9CRLi7CYVhx0O2cQ2BWoSR5VVDIO5MYGXxlvSIwDRaoNjvOdnM+iZlro1/OxbmqFceZqAO+Qkd8PcqP0JItcEfHMhJCN1FAzkNreZ8EU5P80FlvSk3jrBv4MOTRUki4u9tOPr411jIwTGLlSv3Skg10R29TmyRYA9zSWwgMJ9+xVVLtJKK/OBQS6iPXQPb2iNcHRDWf7hfrNVACt4Yz+q2fMvBrvG/oa2JZxovFsz9haAyr/34TEiNvV+BvqDkSK6NUngyRAQ39LrMyOFqQeIqn7rSj4dYxg/nxGgw2RKG22Kak5Bf0xiV6pJzQH9C254RqWpehpsBuZPQ==
+x-microsoft-antispam-prvs: <VI1PR0802MB22569177B2E41F37B207AB51AF450@VI1PR0802MB2256.eurprd08.prod.example.com>
+x-exchange-antispam-report-test: UriScan:(27231711734898)(21748063052155);
+x-exchange-antispam-report-cfa-test: BCL:0;PCL:0;RULEID:(6040375)(601004)(2401047)(8121501046)(5005006)(3002001)(10201501046)(6041248)(20161123558025)(20161123560025)(20161123564025)(20161123562025)(20161123555025)(6072148);SRVR:VI1PR0802MB2256;BCL:0;PCL:0;RULEID:;SRVR:VI1PR0802MB2256;
+x-forefront-prvs: 02135EB356
+x-forefront-antispam-report: SFV:NSPM;SFS:(10019020)(6009001)(7916002)(39450400003)(189002)(199003)(6116002)(6506006)(8936002)(790700001)(102836003)(75922002)(2906002)(101416001)(6306002)(53936002)(5406001)(450100001)(1730700003)(3280700002)(86362001)(558084003)(74316002)(3660700001)(55016002)(122556002)(6916009)(99286003)(54896002)(92566002)(2900100001)(7736002)(81166006)(81156014)(110136004)(2351001)(38730400002)(97736004)(77096006)(3846002)(5640700003)(2501003)(50986999)(33656002)(68736007)(105586002)(5416004)(54356999)(106356001)(25636003)(5660300001)(7696004)(189998001)(6436002)(25786008)(66066001)(9686003)(74482002)(42882006);DIR:OUT;SFP:1102;SCL:1;SRVR:VI1PR0802MB2256;H:VI1PR0802MB2255.eurprd08.prod.example.com;FPR:;SPF:None;PTR:InfoNoRecords;MX:1;A:0;LANG:en;
+received-spf: None (protection.example.com: example.gov.uk does not designate
+ permitted sender hosts)
+spamdiagnosticoutput: 1:99
+spamdiagnosticmetadata: NSPM
+Content-Type: multipart/alternative;
+	boundary="_000_VI1PR0802MB2255937A3640A34E1BBDC8A5AF450VI1PR0802MB2255_"
+MIME-Version: 1.0
+X-OriginatorOrg: example.gov.uk
+X-MS-Exchange-CrossTenant-originalarrivaltime: 09 Feb 2017 13:06:08.6935
+ (UTC)
+X-MS-Exchange-CrossTenant-fromentityheader: Hosted
+X-MS-Exchange-CrossTenant-id: 14aa5744-ece1-474e-a2d7-34f46dda64a1
+X-MS-Exchange-Transport-CrossTenantHeadersStamped: VI1PR0802MB2256
+
+--_000_VI1PR0802MB2255937A3640A34E1BBDC8A5AF450VI1PR0802MB2255_
+Content-Type: text/plain; charset="us-ascii"
+Content-Transfer-Encoding: quoted-printable
+
+07123456789
+This information is exempt under the Freedom of Information Act 2000 (FOIA)=
+ and may be exempt under other UK information legislation. Refer any FOIA q=
+ueries to example@example.gov.uk
+
+--_000_VI1PR0802MB2255937A3640A34E1BBDC8A5AF450VI1PR0802MB2255_
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: quoted-printable
+
+<html xmlns:v=3D"urn:schemas-microsoft-com:vml" xmlns:o=3D"urn:schemas-micr=
+osoft-com:office:office" xmlns:w=3D"urn:schemas-microsoft-com:office:word" =
+xmlns:m=3D"http://schemas.microsoft.com/office/2004/12/omml" xmlns=3D"http:=
+//www.w3.org/TR/REC-html40">
+<head>
+<meta http-equiv=3D"Content-Type" content=3D"text/html; charset=3Dus-ascii"=
+>
+<meta name=3D"Generator" content=3D"Microsoft Word 15 (filtered medium)">
+<style><!--
+/* Font Definitions */
+@font-face
+	{font-family:"Cambria Math";
+	panose-1:2 4 5 3 5 4 6 3 2 4;}
+@font-face
+	{font-family:Calibri;
+	panose-1:2 15 5 2 2 2 4 3 2 4;}
+/* Style Definitions */
+p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{margin:0cm;
+	margin-bottom:.0001pt;
+	font-size:11.0pt;
+	font-family:"Calibri",sans-serif;
+	mso-fareast-language:EN-US;}
+a:link, span.MsoHyperlink
+	{mso-style-priority:99;
+	color:#0563C1;
+	text-decoration:underline;}
+a:visited, span.MsoHyperlinkFollowed
+	{mso-style-priority:99;
+	color:#954F72;
+	text-decoration:underline;}
+span.EmailStyle17
+	{mso-style-type:personal-compose;
+	font-family:"Calibri",sans-serif;
+	color:windowtext;}
+.MsoChpDefault
+	{mso-style-type:export-only;
+	font-family:"Calibri",sans-serif;
+	mso-fareast-language:EN-US;}
+@page WordSection1
+	{size:612.0pt 792.0pt;
+	margin:72.0pt 72.0pt 72.0pt 72.0pt;}
+div.WordSection1
+	{page:WordSection1;}
+--></style><!--[if gte mso 9]><xml>
+<o:shapedefaults v:ext=3D"edit" spidmax=3D"1026" />
+</xml><![endif]--><!--[if gte mso 9]><xml>
+<o:shapelayout v:ext=3D"edit">
+<o:idmap v:ext=3D"edit" data=3D"1" />
+</o:shapelayout></xml><![endif]-->
+</head>
+<body lang=3D"EN-GB" link=3D"#0563C1" vlink=3D"#954F72">
+<div class=3D"WordSection1">
+<p class=3D"MsoNormal"><font size=3D"2" face=3D"Calibri"><span style=3D"fon=
+t-size:11.0pt">07123456789<o:p></o:p></span></font></p>
+</div>
+This information is exempt under the Freedom of Information Act 2000 (FOIA)=
+ and may be exempt under other UK information legislation. Refer any FOIA q=
+ueries to example@example.gov.uk
+</body>
+</html>
+
+--_000_VI1PR0802MB2255937A3640A34E1BBDC8A5AF450VI1PR0802MB2255_--

--- a/spec/lib/email_sponsees_extractor_spec.rb
+++ b/spec/lib/email_sponsees_extractor_spec.rb
@@ -1,0 +1,84 @@
+describe EmailSponseesExtractor do
+  let(:email) { Mail.new }
+  let(:sponsees) { subject.execute(email.to_s) }
+
+  it 'Grabs a single email address' do
+    email.body = 'adrian@example.com'
+    expect(sponsees).to eq(['adrian@example.com'])
+  end
+
+  it 'Ignores an empty line a single email address' do
+    email.body = "\nadrian@example.com"
+    expect(sponsees).to eq(['adrian@example.com'])
+  end
+
+  it 'Plain text email with two sponsees' do
+    email.body = "adrian@example.com\r\nchris@example.com"
+    expect(sponsees).to eq(['adrian@example.com', 'chris@example.com'])
+  end
+
+  it 'Gets email addresses from a multipart email with one text part' do
+    set_text_part("derick@example.com\r\ndan@example.com")
+    expect(sponsees).to eq(['derick@example.com', 'dan@example.com'])
+  end
+
+  it 'Gets an email address from a multipart email with html part' do
+    set_html_part('rick@example.com')
+    expect(sponsees).to eq(['rick@example.com'])
+  end
+
+  it 'Ignores HTML from a multipart email with html part' do
+    set_html_part('<body><p>steve@example.com</p><p>dan@example.com</p></body>')
+    expect(sponsees).to eq(['steve@example.com', 'dan@example.com'])
+  end
+
+  it 'Ignores style tag from a multipart email with html part' do
+    set_html_part('<body><style>body {}</style><p>dan@example.com</p></body>')
+    expect(sponsees).to eq(['dan@example.com'])
+  end
+
+  it 'Returns empty array from an email with invalid HTML' do
+    set_html_part('<body><asd')
+    expect(sponsees).to eq([])
+  end
+
+  it 'Uses the text multipart over the html multipart' do
+    set_html_part('rick@example.com')
+    set_text_part('steve@example.com')
+    expect(sponsees).to eq(['steve@example.com'])
+  end
+
+  context 'Regression tests' do
+    it 'Multipart message' do
+      sponsees = test_case 'email-sponsor-multipart'
+      expect(sponsees.first).to eq('07123456789')
+    end
+
+    it 'Multiple levels of multipart messages' do
+      sponsees = test_case 'email-sponsor-multilevel-multipart'
+      expect(sponsees.first).to eq('example.user2@example.co.uk')
+    end
+
+    it 'Base64 encoded message' do
+      sponsees = test_case('email-sponsor-base64')
+      expect(sponsees).to eq(['example.user2@example.co.uk', '07123456789'])
+    end
+
+    it 'Base64 encoded HTML message' do
+      sponsees = test_case 'email-sponsor-base64-htmlonly'
+      expect(sponsees).to eq(['example.user2@example.co.uk', '07123456789'])
+    end
+
+    def test_case(regression_test_name)
+      subject.execute(File.read("spec/fixtures/#{regression_test_name}.txt"))
+    end
+  end
+
+  def set_text_part(text)
+    email.parts << Mail::Part.new(body: text)
+  end
+
+  def set_html_part(html)
+    email.parts << Mail::Part.new(content_type: 'text/html; charset=UTF-8', body: html)
+  end
+end


### PR DESCRIPTION
To sponsor guests for GovWifi you send an email with their details to sponsor@wifi.service.gov.uk

Each email/phone number appears on a new line.

The regression tests have been pulled over from the PHP test suite.