### PR TITLE
Hook up the SponsorUsers use case to the /email-notification/ route

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'http://rubygems.org'
 ruby File.read('.ruby-version').chomp
 
+gem 'aws-sdk-s3', '~> 1'
 gem 'mail', '~> 2.7'
 gem 'mysql2'
 gem 'nokogiri', '~> 1.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,21 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
+    aws-eventstream (1.0.1)
+    aws-partitions (1.95.0)
+    aws-sdk-core (3.22.1)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.6.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.16.0)
+      aws-sdk-core (~> 3, >= 3.21.2)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
@@ -15,6 +30,7 @@ GEM
       rubocop-rspec (~> 1.19.0)
       scss_lint
     hashdiff (0.3.7)
+    jmespath (1.4.0)
     jwt (2.1.0)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
@@ -94,6 +110,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3 (~> 1)
   govuk-lint
   mail (~> 2.7)
   mysql2

--- a/lib/email_sponsees_extractor.rb
+++ b/lib/email_sponsees_extractor.rb
@@ -1,13 +1,19 @@
 require 'nokogiri'
 
 class EmailSponseesExtractor
-  def execute(email)
-    mail = Mail.read_from_string(email)
+  def initialize(email_fetcher:)
+    @email_fetcher = email_fetcher
+  end
+
+  def execute
+    mail = Mail.read_from_string(email_fetcher.fetch)
 
     contacts_from_mail(mail).map(&:strip).reject(&:empty?)
   end
 
 private
+
+  attr_reader :email_fetcher
 
   def contacts_from_mail(mail)
     if !mail.multipart?

--- a/lib/gateway/s3_object_fetcher.rb
+++ b/lib/gateway/s3_object_fetcher.rb
@@ -1,0 +1,18 @@
+require 'aws-sdk-s3'
+
+class S3ObjectFetcher
+  def initialize(bucket:, key:)
+    @bucket = bucket
+    @key = key
+  end
+
+  def fetch
+    s3 = Aws::S3::Resource.new(region: 'us-west-2')
+    object = s3.get_object(bucket: bucket, key: key)
+    object.body.read
+  end
+
+private
+
+  attr_reader :bucket, :key
+end

--- a/spec/lib/email_sponsees_extractor_spec.rb
+++ b/spec/lib/email_sponsees_extractor_spec.rb
@@ -1,6 +1,9 @@
 describe EmailSponseesExtractor do
   let(:email) { Mail.new }
-  let(:sponsees) { subject.execute(email.to_s) }
+  let(:email_fetcher) { double(fetch: email.to_s) }
+  let(:sponsees) { subject.execute }
+
+  subject { described_class.new(email_fetcher: email_fetcher) }
 
   it 'Grabs a single email address' do
     email.body = 'adrian@example.com'
@@ -50,27 +53,28 @@ describe EmailSponseesExtractor do
 
   context 'Regression tests' do
     it 'Multipart message' do
-      sponsees = test_case 'email-sponsor-multipart'
+      test_case 'email-sponsor-multipart'
       expect(sponsees.first).to eq('07123456789')
     end
 
     it 'Multiple levels of multipart messages' do
-      sponsees = test_case 'email-sponsor-multilevel-multipart'
+      test_case 'email-sponsor-multilevel-multipart'
       expect(sponsees.first).to eq('example.user2@example.co.uk')
     end
 
     it 'Base64 encoded message' do
-      sponsees = test_case('email-sponsor-base64')
+      test_case('email-sponsor-base64')
       expect(sponsees).to eq(['example.user2@example.co.uk', '07123456789'])
     end
 
     it 'Base64 encoded HTML message' do
-      sponsees = test_case 'email-sponsor-base64-htmlonly'
+      test_case 'email-sponsor-base64-htmlonly'
       expect(sponsees).to eq(['example.user2@example.co.uk', '07123456789'])
     end
 
     def test_case(regression_test_name)
-      subject.execute(File.read("spec/fixtures/#{regression_test_name}.txt"))
+      test_raw_email = File.read("spec/fixtures/#{regression_test_name}.txt")
+      allow(email_fetcher).to receive(:fetch).and_return(test_raw_email)
     end
   end
 

--- a/spec/lib/email_sponsees_extractor_spec.rb
+++ b/spec/lib/email_sponsees_extractor_spec.rb
@@ -63,7 +63,7 @@ describe EmailSponseesExtractor do
     end
 
     it 'Base64 encoded message' do
-      test_case('email-sponsor-base64')
+      test_case'email-sponsor-base64'
       expect(sponsees).to eq(['example.user2@example.co.uk', '07123456789'])
     end
 


### PR DESCRIPTION
This integrates SponsorUsers up to the SES/SNS/S3 delivery mechanism.

We differentiate between signup and sponsor email requests, by the local part of the To address attached to the SES message, e.g.  `sponsor@wifi.service.gov.uk`

Also create a small S3 client which pulls down the raw email object from the bucket/object passed through from the SES notification details.