### PR TITLE
Use the Ireland region for the S3 bucket

### DIFF
--- a/lib/gateway/s3_object_fetcher.rb
+++ b/lib/gateway/s3_object_fetcher.rb
@@ -7,7 +7,7 @@ class S3ObjectFetcher
   end
 
   def fetch
-    s3 = Aws::S3::Resource.new(region: 'us-west-2')
+    s3 = Aws::S3::Resource.new(region: 'eu-west-1')
     object = s3.bucket(bucket).object(key)
     object.get.body.read
   end

--- a/spec/lib/gateway/s3_object_fetcher_spec.rb
+++ b/spec/lib/gateway/s3_object_fetcher_spec.rb
@@ -17,7 +17,7 @@ describe S3ObjectFetcher do
       'Token': 'SECURITY_TOKEN_STRING'
     }.to_json)
 
-    stub_request(:get, "https://s3.us-west-2.amazonaws.com/#{bucket}/#{key}") \
+    stub_request(:get, "https://s3.eu-west-1.amazonaws.com/#{bucket}/#{key}") \
       .to_return(body: object_content)
   end
 


### PR DESCRIPTION
They were created in Ireland.  Using the incorrect endpoint gives this error message:

```
  Aws::S3::Errors::PermanentRedirect - The bucket you are attempting
  to access must be addressed using the specified endpoint. Please
  send all future requests to this endpoint.
```