### PR TITLE
Introduce a Contact Sanitiser

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -2,6 +2,7 @@ require 'sinatra/base'
 require 'net/http'
 
 require './lib/email_signup.rb'
+require './lib/contact_sanitiser.rb'
 require './lib/gateway/s3_object_fetcher.rb'
 require './lib/sms_response.rb'
 require './lib/sponsor_users.rb'

--- a/lib/contact_sanitiser.rb
+++ b/lib/contact_sanitiser.rb
@@ -1,0 +1,35 @@
+class ContactSanitiser
+  NO_MATCH = [].freeze
+
+  def execute(contact)
+    first_match(
+      email_match(contact) ||
+      internationalize(phone_match(contact)) ||
+      NO_MATCH
+    )
+  end
+
+private
+
+  def email_match(contact)
+    contact.match(/[A-Za-z0-9\_\+\.\'\-&]+@[a-zA-Z0-9.-]+\.[a-zA-Z]+/)
+  end
+
+  def phone_match(contact)
+    contact.match(/\A\+?\d{1,15}\Z/)
+  end
+
+  def internationalize(match)
+    return [internationalise_phone_number(first_match(match))] if match
+  end
+
+  def first_match(match)
+    match[0]
+  end
+
+  def internationalise_phone_number(phone_number)
+    phone_number = '44' + phone_number[1..-1] if phone_number[0..1] == '07'
+    phone_number = '+' + phone_number unless phone_number[0] == '+'
+    phone_number
+  end
+end

--- a/lib/phone_number.rb
+++ b/lib/phone_number.rb
@@ -1,7 +1,0 @@
-class PhoneNumber
-  def self.internationalise_phone_number(phone_number)
-    phone_number = '44' + phone_number[1..-1] if phone_number[0..1] == '07'
-    phone_number = '+' + phone_number unless phone_number[0] == '+'
-    phone_number
-  end
-end

--- a/lib/sms_response.rb
+++ b/lib/sms_response.rb
@@ -1,5 +1,3 @@
-require_relative 'phone_number'
-
 class SmsResponse
   def initialize(user_model:, template_finder:)
     @user_model = user_model
@@ -7,7 +5,7 @@ class SmsResponse
   end
 
   def execute(contact:, sms_content:)
-    phone_number = PhoneNumber.internationalise_phone_number(contact)
+    phone_number = ContactSanitiser.new.execute(contact)
     login_details = user_model.generate(contact: phone_number)
     notify_params = { login: login_details[:username], pass: login_details[:password] }
     send_signup_instructions(phone_number, notify_params, sms_content)

--- a/spec/lib/contact_sanitiser_spec.rb
+++ b/spec/lib/contact_sanitiser_spec.rb
@@ -1,0 +1,30 @@
+describe ContactSanitiser do
+  it 'strips off mailto in angle brackets' do
+    email = 'emile@gov.uk<mailto:emile@gov.uk>'
+    expect(subject.execute(email)).to eq('emile@gov.uk')
+  end
+
+  it 'strips off appending text' do
+    email = 'adrian@gov.uk Adrian'
+    expect(subject.execute(email)).to eq('adrian@gov.uk')
+  end
+
+  it 'strips off preceding text' do
+    email = 'Chris <chris@gov.uk>'
+    expect(subject.execute(email)).to eq('chris@gov.uk')
+  end
+
+  it 'internationalises a phone number' do
+    phone_number = '07700900004'
+    expect(subject.execute(phone_number)).to eq('+447700900004')
+  end
+
+  it 'passes through an internationalised phone number' do
+    phone_number = '+447700900004'
+    expect(subject.execute(phone_number)).to eq('+447700900004')
+  end
+
+  it 'does not throw an exception when given crap' do
+    expect(subject.execute('asdoihoasdhsioadhj')).to eq(nil)
+  end
+end

--- a/spec/lib/sponsor_users_spec.rb
+++ b/spec/lib/sponsor_users_spec.rb
@@ -17,7 +17,7 @@ describe SponsorUsers do
 
   context 'Sponsoring a single email address' do
     let(:sponsor) { 'Chris <chris@gov.uk>' }
-    let(:sponsees) { ['adrian@example.com'] }
+    let(:sponsees) { ['adrian@example.com<mailto: adrian@example.com>'] }
 
     it 'Calls user_model#generate with the sponsees email' do
       expect(user_model).to have_received(:generate) \
@@ -33,7 +33,7 @@ describe SponsorUsers do
         email_address: 'chris@gov.uk',
         template_id: '30ab6bc5-20bf-45af-b78d-34cacc0027cd',
         personalisation: {
-          contact: sponsees.first
+          contact: 'adrian@example.com'
         }
       }
       expect(a_request(:post, notify_email_url).with(notify_request(body))).to have_been_made.once
@@ -110,7 +110,7 @@ describe SponsorUsers do
         template_id: plural_sponsor_confirmation_template_id,
         personalisation: {
           number_of_accounts: 2,
-          contacts: "Steve <steve@example.com>\r\n07700900004"
+          contacts: "steve@example.com\r\n+447700900004"
         }
       }
       a_request(:post, notify_email_url).with(notify_request(body))
@@ -119,12 +119,11 @@ describe SponsorUsers do
 
   context 'Sponsoring invalid contact details' do
     let(:sponsor) { 'Cassandra <cassandra@gov.uk>' }
-    let(:sponsees) { ['Peter', 'Paul', '07invalid700900004', 'Adrian <adrian@example.com> Invalid'] }
+    let(:sponsees) { %w(Peter Paul 07invalid700900004) }
 
     it 'Does not call user_model#generate' do
       expect(user_model).not_to have_received(:generate)
     end
-
 
     it 'Sends a sponsorship failed email to the sponsor' do
       body = {


### PR DESCRIPTION
Restore original email sanitiser regex to ensure that emails are in a
consistent format for sending signup invites to sponsees.

Previously the system was rejecting emails in the format of
```
clay@example.com<mailto:clay@example.com>
```
Office365 was formatting email addresses in plain text form like
this.

This class will ensure emails are in a valid format along with phone
numbers.  It will also internationalise phone numbers.