### PR TITLE
Change email self signup email template id to be loaded from config

### DIFF
--- a/config/production.yml
+++ b/config/production.yml
@@ -10,6 +10,7 @@ notify_sms_template_ids:
     windows: 801d5deb-6480-4fc6-91e1-da9f5f290c0b
 
 notify_email_template_ids:
+  self_signup_credentials: f18708c0-e857-4f62-b5f3-8f0c75fc2fdb
   sponsored_credentials: fd536b81-bdd7-4b55-98aa-720173718642
   sponsor_confirmation:
     plural: 58e8ef4a-ca6b-40cd-81df-ec9c781fed56

--- a/config/staging.yml
+++ b/config/staging.yml
@@ -10,6 +10,7 @@ notify_sms_template_ids:
     windows: 3b8f158b-22c8-4226-b84b-3ea5085a46d5
 
 notify_email_template_ids:
+  self_signup_credentials: 96d1f5ac-2ebe-41a7-878f-9a569e0bb55c
   sponsored_credentials: 4f6bae31-5add-43a9-b0e3-7db43452676e
   sponsor_confirmation:
     plural: 856a5726-1099-4236-b67c-23b654e9edbf

--- a/lib/email_signup.rb
+++ b/lib/email_signup.rb
@@ -26,8 +26,12 @@ private
 
     client.send_email(
       email_address: email_address,
-      template_id: ENV.fetch('NOTIFY_USER_SIGNUP_EMAIL_TEMPLATE_ID'),
+      template_id: credentials_template_id,
       personalisation: login_details
     )
+  end
+
+  def credentials_template_id
+    YAML.load_file("config/#{ENV['RACK_ENV']}.yml").fetch('notify_email_template_ids').fetch('self_signup_credentials')
   end
 end

--- a/spec/lib/email_signup_spec.rb
+++ b/spec/lib/email_signup_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe EmailSignup do
 
     before do
       ENV['NOTIFY_API_KEY'] = notify_api_key
-      ENV['NOTIFY_USER_SIGNUP_EMAIL_TEMPLATE_ID'] = notify_template_id
+      ENV['RACK_ENV'] = environment
 
       expect(user_model).to receive(:generate) \
         .with(contact: created_contact) \
@@ -31,8 +31,8 @@ RSpec.describe EmailSignup do
 
     context 'given an email address without a name part' do
       let(:created_contact) { 'adrian@gov.uk' }
-
-      let(:notify_template_id) { '00000000-1234-4321-1234-000000000000' }
+      let(:environment) { 'production' }
+      let(:notify_template_id) { 'f18708c0-e857-4f62-b5f3-8f0c75fc2fdb' }
       let(:username) { 'MockUsername' }
       let(:password) { 'MockPassword' }
 
@@ -44,8 +44,8 @@ RSpec.describe EmailSignup do
 
     context 'given an email address with a name part' do
       let(:created_contact) { 'ryan@gov.uk' }
-
-      let(:notify_template_id) { '00000000-6789-9876-6789-000000000000' }
+      let(:environment) { 'staging' }
+      let(:notify_template_id) { '96d1f5ac-2ebe-41a7-878f-9a569e0bb55c' }
       let(:username) { 'MockUsername2' }
       let(:password) { 'MockPassword2' }
 


### PR DESCRIPTION
To make the email self signup consistent with the SMS and sponsor
use cases we'll load the template id in from the config/*.yml file