### PR TITLE
Prevent Error When Subscribing to SNS Topics

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -23,7 +23,7 @@ class App < Sinatra::Base
     payload = JSON.parse request.body.read
 
     Net::HTTP.get(URI(payload['SubscribeURL'])) if payload['Type'] == 'SubscriptionConfirmation'
-    handle_notification(payload) if payload['Type'] == 'Notification'
+    handle_email_notification(payload) if payload['Type'] == 'Notification'
     ''
   end
 
@@ -44,8 +44,10 @@ class App < Sinatra::Base
 
 private
 
-  def handle_notification(payload)
+  def handle_email_notification(payload)
     ses_notification = JSON.parse(payload['Message'])
+    return if ses_notification['mail']['messageId'] == 'AMAZON_SES_SETUP_NOTIFICATION'
+
     if sponsor_request?(ses_notification)
       handle_sponsor_request(ses_notification)
     else

--- a/spec/email_notification_spec.rb
+++ b/spec/email_notification_spec.rb
@@ -101,5 +101,19 @@ RSpec.describe App do
                                    .with(['a_fantastic_email@example.com'], 'chris@example.com')
       end
     end
+
+    describe 'POSTing a Amazon SES Setup Notification to /user-signup/email-notification' do
+      let(:ses_notification) do
+        {
+          mail: {
+            messageId: 'AMAZON_SES_SETUP_NOTIFICATION'
+          }
+        }
+      end
+
+      it 'ignores the message' do
+        expect { post_notification }.to_not(raise_error)
+      end
+    end
   end
 end


### PR DESCRIPTION
When you subscribe to a SNS topic, Amazon will notify that endpoint with
a notification.  The app is expecting only signup requests, so this is
causing an error.  Simply ignore this message.