### PR TITLE
Move SNS behaviour from Sinatras app.rb to a new class

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,6 +1,7 @@
 require 'sinatra/base'
 require 'net/http'
 
+require './lib/sns_notification_handler.rb'
 require './lib/email_signup.rb'
 require './lib/contact_sanitiser.rb'
 require './lib/gateway/s3_object_fetcher.rb'
@@ -20,11 +21,7 @@ class App < Sinatra::Base
   end
 
   post '/user-signup/email-notification' do
-    payload = JSON.parse request.body.read
-
-    Net::HTTP.get(URI(payload['SubscribeURL'])) if payload['Type'] == 'SubscriptionConfirmation'
-    handle_email_notification(payload) if payload['Type'] == 'Notification'
-    ''
+    SnsNotificationHandler.new(logger).handle(request)
   end
 
   post '/user-signup/sms-notification' do
@@ -40,41 +37,5 @@ class App < Sinatra::Base
       sms_content: params[:message]
     )
     ''
-  end
-
-private
-
-  def handle_email_notification(payload)
-    ses_notification = JSON.parse(payload['Message'])
-    return if ses_notification['mail']['messageId'] == 'AMAZON_SES_SETUP_NOTIFICATION'
-
-    if sponsor_request?(ses_notification)
-      handle_sponsor_request(ses_notification)
-    else
-      handle_signup_request(ses_notification)
-    end
-  end
-
-  def sponsor_request?(ses_notification)
-    recipient_name(ses_notification) == "sponsor"
-  end
-
-  def recipient_name(ses_notification)
-    Mail::Address.new(ses_notification['mail']['commonHeaders']['to'][0]).local
-  end
-
-  def handle_signup_request(ses_notification)
-    from_address = ses_notification['mail']['commonHeaders']['from'][0]
-    logger.info("Handling signup request from #{from_address}")
-    EmailSignup.new(user_model: User.new).execute(contact: from_address)
-  end
-
-  def handle_sponsor_request(ses_notification)
-    from_address = ses_notification['mail']['commonHeaders']['from'][0]
-    action = ses_notification['receipt']['action']
-    logger.info("Handling sponsor request from #{from_address} with email #{action['objectKey']}")
-    email_fetcher = S3ObjectFetcher.new(bucket: action['bucketName'], key: action['objectKey'])
-    sponsee_extractor = EmailSponseesExtractor.new(email_fetcher: email_fetcher)
-    SponsorUsers.new(user_model: User.new).execute(sponsee_extractor.execute, from_address)
   end
 end

--- a/lib/sns_notification_handler.rb
+++ b/lib/sns_notification_handler.rb
@@ -1,0 +1,51 @@
+class SnsNotificationHandler
+  def initialize(logger)
+    @logger = logger
+  end
+
+  def handle(request)
+    payload = JSON.parse request.body.read
+
+    Net::HTTP.get(URI(payload['SubscribeURL'])) if payload['Type'] == 'SubscriptionConfirmation'
+    handle_email_notification(payload) if payload['Type'] == 'Notification'
+    ''
+  end
+
+private
+
+  attr_reader :logger
+
+  def handle_email_notification(payload)
+    ses_notification = JSON.parse(payload['Message'])
+    return if ses_notification['mail']['messageId'] == 'AMAZON_SES_SETUP_NOTIFICATION'
+
+    if sponsor_request?(ses_notification)
+      handle_sponsor_request(ses_notification)
+    else
+      handle_signup_request(ses_notification)
+    end
+  end
+
+  def sponsor_request?(ses_notification)
+    recipient_name(ses_notification) == "sponsor"
+  end
+
+  def recipient_name(ses_notification)
+    Mail::Address.new(ses_notification['mail']['commonHeaders']['to'][0]).local
+  end
+
+  def handle_signup_request(ses_notification)
+    from_address = ses_notification['mail']['commonHeaders']['from'][0]
+    logger.info("Handling signup request from #{from_address}")
+    EmailSignup.new(user_model: User.new).execute(contact: from_address)
+  end
+
+  def handle_sponsor_request(ses_notification)
+    from_address = ses_notification['mail']['commonHeaders']['from'][0]
+    action = ses_notification['receipt']['action']
+    logger.info("Handling sponsor request from #{from_address} with email #{action['objectKey']}")
+    email_fetcher = S3ObjectFetcher.new(bucket: action['bucketName'], key: action['objectKey'])
+    sponsee_extractor = EmailSponseesExtractor.new(email_fetcher: email_fetcher)
+    SponsorUsers.new(user_model: User.new).execute(sponsee_extractor.execute, from_address)
+  end
+end


### PR DESCRIPTION
app.rb was starting to inherit lots of SNS, and SES responsibilities
and knowledge.  Splitting this behaviour into a new class helps
keep app.rb generic to the routes it needs to know about.