### PR TITLE
Disable the auto confirmation behaviour for SNS

### DIFF
--- a/lib/sns_notification_handler.rb
+++ b/lib/sns_notification_handler.rb
@@ -6,7 +6,7 @@ class SnsNotificationHandler
   def handle(request)
     payload = JSON.parse request.body.read
 
-    Net::HTTP.get(URI(payload['SubscribeURL'])) if payload['Type'] == 'SubscriptionConfirmation'
+    logger.info(payload) if payload['Type'] == 'SubscriptionConfirmation'
     handle_email_notification(payload) if payload['Type'] == 'Notification'
     ''
   end

--- a/spec/email_notification_spec.rb
+++ b/spec/email_notification_spec.rb
@@ -1,15 +1,6 @@
 RSpec.describe App do
   before { ENV['AUTHORISED_EMAIL_DOMAINS_REGEX'] = '.gov.uk$' }
 
-  describe 'POSTing a SubscriptionConfirmation to /user-signup/email-notification' do
-    it 'makes a GET request to the SubscribeURL' do
-      stub_request(:any, 'www.example.com')
-      post '/user-signup/email-notification', { Type: 'SubscriptionConfirmation', SubscribeURL: 'http://www.example.com' }.to_json
-
-      expect(WebMock).to have_requested(:get, 'www.example.com')
-    end
-  end
-
   describe 'POSTing a Notification to /user-signup/email-notification' do
     let(:bucket_name) { 'stub-bucket-name' }
     let(:object_key) { 'stub-object-key' }


### PR DESCRIPTION
The auto confirmation behaviour was requried when setting
up the endpoint with SNS, but is no longer required as it
is now subscribed to SNS.

By leaving this functionality inside the app we allow other
SNS queues to subscribe to this endpoint, which we don't want
to allow.

Instead print out the notification to the logger, which allows
us to manually subscribe if ever required.