### PR TITLE
Add email and sponsored signups to statistics

### DIFF
--- a/lib/gateway/stat_gateway.rb
+++ b/lib/gateway/stat_gateway.rb
@@ -12,37 +12,31 @@ class StatGateway
 
 private
 
+  def repository
+    SignUp
+  end
+
   def signups_today
-    User
-      .where(Sequel[:created_at] > Date.today)
-      .where(Sequel[:created_at] < Date.today + 1)
+    repository.all.today
   end
 
   def signups_total
-    User.where(Sequel[:created_at] < Date.today + 1)
+    repository.all
   end
 
   def sms_signups_today
-    signups_today
-      .where(Sequel.like(:contact, '+%'))
-      .where(contact: Sequel[:sponsor])
+    signups_today.self_sign.with_sms
   end
 
   def sms_signups_total
-    signups_total
-      .where(Sequel.like(:contact, '+%'))
-      .where(contact: Sequel[:sponsor])
+    signups_total.self_sign.with_sms
   end
 
   def email_signups_today
-    signups_today
-      .where(Sequel.like(:contact, '%@%'))
-      .where(contact: Sequel[:sponsor])
+    signups_today.self_sign.with_email
   end
 
   def email_signups_total
-    signups_total
-      .where(Sequel.like(:contact, '%@%'))
-      .where(contact: Sequel[:sponsor])
+    signups_total.self_sign.with_email
   end
 end

--- a/lib/gateway/stat_gateway.rb
+++ b/lib/gateway/stat_gateway.rb
@@ -2,11 +2,13 @@ class StatGateway
   def signups
     {
       today: signups_today.count,
-      total: signups_total.count,
+      cumulative: signups_cumulative.count,
       sms_today: sms_signups_today.count,
-      sms_total: sms_signups_total.count,
+      sms_cumulative: sms_signups_cumulative.count,
       email_today: email_signups_today.count,
-      email_total: email_signups_total.count
+      email_cumulative: email_signups_cumulative.count,
+      sponsored_today: sponsored_signups_today.count,
+      sponsored_cumulative: sponsored_signups_cumulative.count
     }
   end
 
@@ -20,7 +22,7 @@ private
     repository.all.today
   end
 
-  def signups_total
+  def signups_cumulative
     repository.all
   end
 
@@ -28,15 +30,23 @@ private
     signups_today.self_sign.with_sms
   end
 
-  def sms_signups_total
-    signups_total.self_sign.with_sms
+  def sms_signups_cumulative
+    signups_cumulative.self_sign.with_sms
   end
 
   def email_signups_today
     signups_today.self_sign.with_email
   end
 
-  def email_signups_total
-    signups_total.self_sign.with_email
+  def email_signups_cumulative
+    signups_cumulative.self_sign.with_email
+  end
+
+  def sponsored_signups_cumulative
+    signups_cumulative.sponsored
+  end
+
+  def sponsored_signups_today
+    signups_today.sponsored.today
   end
 end

--- a/lib/gateway/stat_gateway.rb
+++ b/lib/gateway/stat_gateway.rb
@@ -4,7 +4,9 @@ class StatGateway
       today: signups_today.count,
       total: signups_total.count,
       sms_today: sms_signups_today.count,
-      sms_total: sms_signups_total.count
+      sms_total: sms_signups_total.count,
+      email_today: email_signups_today.count,
+      email_total: email_signups_total.count
     }
   end
 
@@ -29,6 +31,18 @@ private
   def sms_signups_total
     signups_total
       .where(Sequel.like(:contact, '+%'))
+      .where(contact: Sequel[:sponsor])
+  end
+
+  def email_signups_today
+    signups_today
+      .where(Sequel.like(:contact, '%@%'))
+      .where(contact: Sequel[:sponsor])
+  end
+
+  def email_signups_total
+    signups_total
+      .where(Sequel.like(:contact, '%@%'))
       .where(contact: Sequel[:sponsor])
   end
 end

--- a/lib/model/sign_up.rb
+++ b/lib/model/sign_up.rb
@@ -12,6 +12,10 @@ class SignUp < Sequel::Model(:userdetails)
       where(contact: Sequel[:sponsor])
     end
 
+    def sponsored
+      exclude(contact: Sequel[:sponsor])
+    end
+
     def with_sms
       where(Sequel.like(:contact, '+%'))
     end

--- a/lib/model/sign_up.rb
+++ b/lib/model/sign_up.rb
@@ -1,0 +1,23 @@
+class SignUp < Sequel::Model(:userdetails)
+  dataset_module do
+    def all
+      where(Sequel[:created_at] < Date.today + 1)
+    end
+
+    def today
+      where(Sequel[:created_at] > Date.today)
+    end
+
+    def self_sign
+      where(contact: Sequel[:sponsor])
+    end
+
+    def with_sms
+      where(Sequel.like(:contact, '+%'))
+    end
+
+    def with_email
+      where(Sequel.like(:contact, '%@%'))
+    end
+  end
+end

--- a/spec/lib/gateway/stat_gateway_spec.rb
+++ b/spec/lib/gateway/stat_gateway_spec.rb
@@ -4,12 +4,17 @@ describe StatGateway do
   end
 
   context 'given no signups' do
-    it 'returns zero signups for today' do
-      expect(subject.signups[:today]).to eq(0)
-    end
-
-    it 'returns zero signups for today' do
-      expect(subject.signups[:total]).to eq(0)
+    it 'returns stats with zero signups' do
+      expect(subject.signups).to eq(
+        today: 0,
+        cumulative: 0,
+        sms_today: 0,
+        sms_cumulative: 0,
+        email_today: 0,
+        email_cumulative: 0,
+        sponsored_cumulative: 0,
+        sponsored_today: 0
+      )
     end
   end
 
@@ -24,8 +29,8 @@ describe StatGateway do
       expect(subject.signups[:today]).to eq(3)
     end
 
-    it 'returns same total number of signups' do
-      expect(subject.signups[:total]).to eq(3)
+    it 'returns same cumulative number of signups' do
+      expect(subject.signups[:cumulative]).to eq(3)
     end
   end
 
@@ -42,8 +47,8 @@ describe StatGateway do
       expect(subject.signups[:today]).to eq(5)
     end
 
-    it 'returns zero signups 6 signups total' do
-      expect(subject.signups[:total]).to eq(6)
+    it 'returns zero signups 6 signups cumulative' do
+      expect(subject.signups[:cumulative]).to eq(6)
     end
   end
 
@@ -58,8 +63,8 @@ describe StatGateway do
       expect(subject.signups[:today]).to eq(0)
     end
 
-    it 'returns zero signups total' do
-      expect(subject.signups[:today]).to eq(0)
+    it 'returns zero signups cumulative' do
+      expect(subject.signups[:cumulative]).to eq(0)
     end
   end
 
@@ -84,24 +89,24 @@ describe StatGateway do
         )
     end
 
-    it 'counts all of them against total singups' do
-      expect(subject.signups[:total]).to eq(3)
+    it 'counts all of them against cumulative singups' do
+      expect(subject.signups[:cumulative]).to eq(3)
     end
 
     it 'counts all of them against todays signups' do
       expect(subject.signups[:today]).to eq(3)
     end
 
-    it 'calculates SMS total signups' do
-      expect(subject.signups[:sms_total]).to eq(1)
+    it 'calculates SMS cumulative signups' do
+      expect(subject.signups[:sms_cumulative]).to eq(1)
     end
 
     it 'calculates SMS todays signups' do
       expect(subject.signups[:sms_today]).to eq(1)
     end
 
-    it 'calculates email total signups' do
-      expect(subject.signups[:email_total]).to eq(2)
+    it 'calculates email cumulative signups' do
+      expect(subject.signups[:email_cumulative]).to eq(2)
     end
 
     it 'calculates email todays signups' do
@@ -125,16 +130,16 @@ describe StatGateway do
         )
     end
 
-    it 'counts them against total singups' do
-      expect(subject.signups[:total]).to eq(2)
+    it 'counts them against cumulative singups' do
+      expect(subject.signups[:cumulative]).to eq(2)
     end
 
     it 'counts them against todays signups' do
       expect(subject.signups[:today]).to eq(1)
     end
 
-    it 'counts them against SMS total signups' do
-      expect(subject.signups[:sms_total]).to eq(2)
+    it 'counts them against SMS cumulative signups' do
+      expect(subject.signups[:sms_cumulative]).to eq(2)
     end
 
     it 'counts them against SMS todays signups' do
@@ -158,20 +163,45 @@ describe StatGateway do
         )
     end
 
-    it 'counts them against total singups' do
-      expect(subject.signups[:total]).to eq(2)
+    it 'counts them against cumulative singups' do
+      expect(subject.signups[:cumulative]).to eq(2)
     end
 
     it 'counts them against todays signups' do
       expect(subject.signups[:today]).to eq(1)
     end
 
-    it 'counts them against email total signups' do
-      expect(subject.signups[:email_total]).to eq(2)
+    it 'counts them against email cumulative signups' do
+      expect(subject.signups[:email_cumulative]).to eq(2)
     end
 
-    it 'counts them against email todays signups' do
+    it 'counts them against email signups today' do
       expect(subject.signups[:email_today]).to eq(1)
+    end
+  end
+
+  context 'given sponsored sign ups' do
+    before do
+      User.create(
+        username: 'Email',
+        contact: 'foo@bar.com',
+        sponsor: 'sponsor@bar.com'
+        )
+
+      User.create(
+        username: 'SMS',
+        contact: 'foo@baz.com',
+        sponsor: 'sponsor@baz.com',
+        created_at: Date.today - 1
+        )
+    end
+
+    it 'counts both of them to cumulative number of sponsored sign ups' do
+      expect(subject.signups[:sponsored_cumulative]).to eq(2)
+    end
+
+    it 'counts one of them as sponsored sign up today' do
+      expect(subject.signups[:sponsored_today]).to eq(1)
     end
   end
 end

--- a/spec/lib/gateway/stat_gateway_spec.rb
+++ b/spec/lib/gateway/stat_gateway_spec.rb
@@ -63,9 +63,19 @@ describe StatGateway do
     end
   end
 
-  context 'given 1 SMS signup today' do
+  context 'given 1 SMS signup today and 2 email signups' do
     before do
-      User.create(username: "non-SMS")
+      User.create(
+        username: 'Email 1',
+        contact: 'foo@bar.com',
+        sponsor: 'foo@bar.com'
+        )
+
+      User.create(
+        username: 'Email 2', 
+        contact: 'foo@baz.com',
+        sponsor: 'foo@baz.com'
+        )
 
       User.create(
         username: "SMS",
@@ -74,20 +84,28 @@ describe StatGateway do
         )
     end
 
-    it 'counts them against total singups' do
-      expect(subject.signups[:total]).to eq(2)
+    it 'counts all of them against total singups' do
+      expect(subject.signups[:total]).to eq(3)
     end
 
-    it 'counts them against todays signups' do
-      expect(subject.signups[:today]).to eq(2)
+    it 'counts all of them against todays signups' do
+      expect(subject.signups[:today]).to eq(3)
     end
 
-    it 'counts them against SMS total signups' do
+    it 'calculates SMS total signups' do
       expect(subject.signups[:sms_total]).to eq(1)
     end
 
-    it 'counts them against SMS todays signups' do
+    it 'calculates SMS todays signups' do
       expect(subject.signups[:sms_today]).to eq(1)
+    end
+
+    it 'calculates SMS total signups' do
+      expect(subject.signups[:email_total]).to eq(2)
+    end
+
+    it 'calculates SMS todays signups' do
+      expect(subject.signups[:email_today]).to eq(2)
     end
   end
 

--- a/spec/lib/gateway/stat_gateway_spec.rb
+++ b/spec/lib/gateway/stat_gateway_spec.rb
@@ -72,7 +72,7 @@ describe StatGateway do
         )
 
       User.create(
-        username: 'Email 2', 
+        username: 'Email 2',
         contact: 'foo@baz.com',
         sponsor: 'foo@baz.com'
         )
@@ -100,11 +100,11 @@ describe StatGateway do
       expect(subject.signups[:sms_today]).to eq(1)
     end
 
-    it 'calculates SMS total signups' do
+    it 'calculates email total signups' do
       expect(subject.signups[:email_total]).to eq(2)
     end
 
-    it 'calculates SMS todays signups' do
+    it 'calculates email todays signups' do
       expect(subject.signups[:email_today]).to eq(2)
     end
   end
@@ -139,6 +139,39 @@ describe StatGateway do
 
     it 'counts them against SMS todays signups' do
       expect(subject.signups[:sms_today]).to eq(1)
+    end
+  end
+
+  context 'given email signups made on different dates' do
+    before do
+      User.create(
+        username: "Email old",
+        created_at: Date.today - 1,
+        contact: 'foo@bar.com',
+        sponsor: 'foo@bar.com'
+        )
+
+      User.create(
+        username: "Email new",
+        contact: 'foo@baz.com',
+        sponsor: 'foo@baz.com'
+        )
+    end
+
+    it 'counts them against total singups' do
+      expect(subject.signups[:total]).to eq(2)
+    end
+
+    it 'counts them against todays signups' do
+      expect(subject.signups[:today]).to eq(1)
+    end
+
+    it 'counts them against email total signups' do
+      expect(subject.signups[:email_total]).to eq(2)
+    end
+
+    it 'counts them against email todays signups' do
+      expect(subject.signups[:email_today]).to eq(1)
     end
   end
 end


### PR DESCRIPTION
* add email signups to statistics
* add sponsored signups to statistics
* introduce `SignUp` model to deal with Sequel queries for statistics
* and use that model as a repository for a gateway (not injected because it's fairly simple so far)