### PR TITLE
Handle HTTP errors from Performence service API

### DIFF
--- a/lib/gateway/performance_platform_gateway.rb
+++ b/lib/gateway/performance_platform_gateway.rb
@@ -1,3 +1,5 @@
+class PerformancePlatformError < StandardError; end
+
 class PerformancePlatformGateway
   def send_stats(data)
     uri = URI("#{ENV['PERFORMANCE_URL']}data/gov-wifi/volumetrics")
@@ -14,7 +16,12 @@ private
     request.body = data.to_json
 
     Net::HTTP.start(uri.hostname, 443, use_ssl: true) do |http|
-      JSON.parse(http.request(request).body)
+      response = http.request(request)
+
+      raise PerformancePlatformError, "#{response.code} - #{response.body}" \
+        unless response.code == '200'
+
+      JSON.parse(response.body)
     end
   end
 end

--- a/spec/lib/gateway/performace_platform_gateway_spec.rb
+++ b/spec/lib/gateway/performace_platform_gateway_spec.rb
@@ -1,5 +1,6 @@
 describe PerformancePlatformGateway do
   let(:endpoint) { 'https://performance-platform/' }
+  let(:data) { [{ foo: :bar }] }
 
   before do
     ENV['PERFORMANCE_BEARER_VOLUMETRICS'] = 'foobarbaz'
@@ -15,18 +16,28 @@ describe PerformancePlatformGateway do
     )
     .to_return(
       body: response.to_json,
-      status: 200
+      status: response_code
     )
   end
 
   context 'with valid data sent' do
-    let(:data) { [{ foo: :bar }] }
     let(:response) { { status: 'ok' } }
+    let(:response_code) { 200 }
 
     it 'returns an OK response' do
       result = subject.send_stats(data)
 
       expect(result['status']).to eq('ok')
+    end
+  end
+
+  context 'with invalid data' do
+    let(:response) { 'error message' }
+    let(:response_code) { 403 }
+
+    it 'rasises an error' do
+      expect { subject.send_stats(data) }.to \
+        raise_error(PerformancePlatformError, '403 - "error message"')
     end
   end
 end


### PR DESCRIPTION
If we receive an error when calling Performance service API,
we raise it so that Raven can catch it and report to Sentry.