### PR TITLE
Change domain-checking RegEx to case-insensitive

### DIFF
--- a/lib/common/email_address.rb
+++ b/lib/common/email_address.rb
@@ -4,6 +4,6 @@ class Common::EmailAddress
   end
 
   def self.authorised_email_domains_regex
-    Regexp.new(ENV.fetch('AUTHORISED_EMAIL_DOMAINS_REGEX'))
+    Regexp.new(ENV.fetch('AUTHORISED_EMAIL_DOMAINS_REGEX'), Regexp::IGNORECASE)
   end
 end


### PR DESCRIPTION
Valid domains (ones which are allowed to sign up to GovWifi) are all `.gov`, but some might be `DOMAIN.gov` - this change allows any casing email to sign up successfully.

This commit also includes some small refactoring of the associated test suite, more to go.