### PR TITLE
Fix typo with instantiating the Volumetrics presenter

### DIFF
--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -1,7 +1,7 @@
 task :publish_daily_statistics do
   performance_gateway = PerformancePlatform::Gateway::PerformanceReport.new
   volumetrics_gateway = PerformancePlatform::Gateway::Volumetrics.new
-  volumetrics_presenter = PerformancePlatform::Presenter::Volumetrics
+  volumetrics_presenter = PerformancePlatform::Presenter::Volumetrics.new
 
   PerformancePlatform::UseCase::SendPerformanceReport.new(
     stats_gateway: volumetrics_gateway,


### PR DESCRIPTION
These object instantiations/hooking up aren't currently covered by tests.  It may make sense in the future to create an acceptance spec which runs through this.