### PR TITLE
Send signup statistics from yesterday not today

### DIFF
--- a/lib/performance_platform/gateway/volumetrics.rb
+++ b/lib/performance_platform/gateway/volumetrics.rb
@@ -3,13 +3,13 @@ class PerformancePlatform::Gateway::Volumetrics
     {
       period: 'day',
       metric_name: 'volumetrics',
-      today: signups_today.count,
+      yesterday: signups_yesterday.count,
       cumulative: signups_cumulative.count,
-      sms_today: sms_signups_today.count,
+      sms_yesterday: sms_signups_yesterday.count,
       sms_cumulative: sms_signups_cumulative.count,
-      email_today: email_signups_today.count,
+      email_yesterday: email_signups_yesterday.count,
       email_cumulative: email_signups_cumulative.count,
-      sponsored_today: sponsored_signups_today.count,
+      sponsored_yesterday: sponsored_signups_yesterday.count,
       sponsored_cumulative: sponsored_signups_cumulative.count
     }
   end
@@ -20,24 +20,24 @@ private
     PerformancePlatform::Repository::SignUp
   end
 
-  def signups_today
-    repository.all.today
+  def signups_yesterday
+    repository.yesterday
   end
 
   def signups_cumulative
     repository.all
   end
 
-  def sms_signups_today
-    signups_today.self_sign.with_sms
+  def sms_signups_yesterday
+    signups_yesterday.self_sign.with_sms
   end
 
   def sms_signups_cumulative
     signups_cumulative.self_sign.with_sms
   end
 
-  def email_signups_today
-    signups_today.self_sign.with_email
+  def email_signups_yesterday
+    signups_yesterday.self_sign.with_email
   end
 
   def email_signups_cumulative
@@ -48,7 +48,7 @@ private
     signups_cumulative.sponsored
   end
 
-  def sponsored_signups_today
-    signups_today.sponsored.today
+  def sponsored_signups_yesterday
+    signups_yesterday.sponsored
   end
 end

--- a/lib/performance_platform/presenter/volumetrics.rb
+++ b/lib/performance_platform/presenter/volumetrics.rb
@@ -6,10 +6,10 @@ class PerformancePlatform::Presenter::Volumetrics
     {
       metric_name: stats[:metric_name],
       payload: [
-        as_hash(stats[:today], stats[:cumulative], 'all-sign-ups'),
-        as_hash(stats[:sms_today], stats[:sms_cumulative], 'sms-sign-ups'),
-        as_hash(stats[:email_today], stats[:email_cumulative], 'email-sign-ups'),
-        as_hash(stats[:sponsored_today], stats[:sponsored_cumulative], 'sponsored-sign-ups'),
+        as_hash(stats[:yesterday], stats[:cumulative], 'all-sign-ups'),
+        as_hash(stats[:sms_yesterday], stats[:sms_cumulative], 'sms-sign-ups'),
+        as_hash(stats[:email_yesterday], stats[:email_cumulative], 'email-sign-ups'),
+        as_hash(stats[:sponsored_yesterday], stats[:sponsored_cumulative], 'sponsored-sign-ups'),
       ]
     }
   end
@@ -17,7 +17,7 @@ class PerformancePlatform::Presenter::Volumetrics
 private
 
   def generate_timestamp
-    "#{Date.today}T00:00:00+00:00"
+    "#{Date.today - 1}T00:00:00+00:00"
   end
 
   def as_hash(count, cumulative_count, channel)

--- a/lib/performance_platform/repository/sign_up.rb
+++ b/lib/performance_platform/repository/sign_up.rb
@@ -1,11 +1,11 @@
 class PerformancePlatform::Repository::SignUp < Sequel::Model(:userdetails)
   dataset_module do
     def all
-      where(Sequel[:created_at] < Date.today + 1)
+      where(Sequel.lit("date(created_at) <= '#{Date.today - 1}'"))
     end
 
-    def today
-      where(Sequel[:created_at] > Date.today)
+    def yesterday
+      where(Sequel.lit("date(created_at) = '#{Date.today - 1}'"))
     end
 
     def self_sign

--- a/spec/unit/lib/performance_platform/use_case/send_performance_report_spec.rb
+++ b/spec/unit/lib/performance_platform/use_case/send_performance_report_spec.rb
@@ -44,13 +44,13 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
       {
         metric_name: 'volumetrics',
         period: 'day',
-        today: 12,
+        yesterday: 12,
         cumulative: 24,
-        sms_today: 2,
+        sms_yesterday: 2,
         sms_cumulative: 3,
-        email_today: 10,
+        email_yesterday: 10,
         email_cumulative: 21,
-        sponsored_today: 7,
+        sponsored_yesterday: 7,
         sponsored_cumulative: 9
       }
     }


### PR DESCRIPTION
Based on the current functionality, we only send statistics from the day
before, not today.

Fix date comparison functionality to compare against date only, not
time.