### PR TITLE
Fix between syntax for finding results from 2 weeks ago

### DIFF
--- a/lib/performance_platform/repository/sign_up.rb
+++ b/lib/performance_platform/repository/sign_up.rb
@@ -25,7 +25,7 @@ class PerformancePlatform::Repository::SignUp < Sequel::Model(:userdetails)
     end
 
     def last_week
-      where(created_at: (Date.today - 14)..(Date.today - 7))
+      where(Sequel.lit("date(created_at) BETWEEN '#{Date.today - 14}' AND '#{Date.today - 7}'"))
     end
 
     def with_successful_login


### PR DESCRIPTION
This sequel syntax doesn't mirror what the existing mysql does and we
are getting different results.  By changing the sequel to use BETWEEN
and using the mysql date() function, it fixes it