### PR TITLE
Fix sponsor-sign-ups key

### DIFF
--- a/lib/performance_platform/presenter/volumetrics.rb
+++ b/lib/performance_platform/presenter/volumetrics.rb
@@ -9,7 +9,7 @@ class PerformancePlatform::Presenter::Volumetrics
         as_hash(stats[:yesterday], stats[:cumulative], 'all-sign-ups'),
         as_hash(stats[:sms_yesterday], stats[:sms_cumulative], 'sms-sign-ups'),
         as_hash(stats[:email_yesterday], stats[:email_cumulative], 'email-sign-ups'),
-        as_hash(stats[:sponsored_yesterday], stats[:sponsored_cumulative], 'sponsored-sign-ups'),
+        as_hash(stats[:sponsored_yesterday], stats[:sponsored_cumulative], 'sponsor-sign-ups'),
       ]
     }
   end

--- a/spec/unit/lib/performance_platform/use_case/send_performance_report_spec.rb
+++ b/spec/unit/lib/performance_platform/use_case/send_performance_report_spec.rb
@@ -88,11 +88,11 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
             cumulative_count: 21
           },
           {
-            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpZGF5dm9sdW1ldHJpY3NzcG9uc29yZWQtc2lnbi11cHM=',
+            _id: 'MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpZGF5dm9sdW1ldHJpY3NzcG9uc29yLXNpZ24tdXBz',
             _timestamp: '2018-07-16T00:00:00+00:00',
             dataType: 'volumetrics',
             period: 'day',
-            channel: 'sponsored-sign-ups',
+            channel: 'sponsor-sign-ups',
             count: 7,
             cumulative_count: 9
           }


### PR DESCRIPTION
There was a typo where the 'sponsor-sign-ups' key sent to the
performance platform was incorrect, it was previously 'sponsored-sign-ups'