### PR TITLE
Allow the date to be overriden for performance stats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,6 @@ group :test do
   gem 'govuk-lint'
   gem 'rack-test'
   gem 'rspec'
+  gem 'timecop'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
       rack-protection (= 2.0.3)
       tilt (~> 2.0)
     tilt (2.0.8)
+    timecop (0.9.1)
     unicode-display_width (1.4.0)
     webmock (3.4.2)
       addressable (>= 2.3.6)
@@ -125,6 +126,7 @@ DEPENDENCIES
   sentry-raven
   sequel (~> 5.11)
   sinatra
+  timecop
   webmock
 
 RUBY VERSION

--- a/lib/performance_platform/gateway/completion_rate.rb
+++ b/lib/performance_platform/gateway/completion_rate.rb
@@ -1,4 +1,8 @@
 class PerformancePlatform::Gateway::CompletionRate
+  def initialize(date: Date.today.to_s)
+    @date = Date.parse(date)
+  end
+
   def fetch_stats
     {
       period: 'week',
@@ -14,20 +18,22 @@ class PerformancePlatform::Gateway::CompletionRate
 
 private
 
+  attr_reader :date
+
   def repository
     PerformancePlatform::Repository::SignUp
   end
 
   def sms_registered
-    repository.self_sign.with_sms.last_week
+    repository.self_sign.with_sms.week_before(date)
   end
 
   def email_registered
-    repository.self_sign.with_email.last_week
+    repository.self_sign.with_email.week_before(date)
   end
 
   def sponsor_registered
-    repository.sponsored.last_week
+    repository.sponsored.week_before(date)
   end
 
   def sms_logged_in

--- a/lib/performance_platform/gateway/volumetrics.rb
+++ b/lib/performance_platform/gateway/volumetrics.rb
@@ -1,43 +1,49 @@
 class PerformancePlatform::Gateway::Volumetrics
+  def initialize(date: Date.today.to_s)
+    @date = Date.parse(date)
+  end
+
   def fetch_stats
     {
       period: 'day',
       metric_name: 'volumetrics',
-      yesterday: signups_yesterday.count,
+      day_before: signups_day_before.count,
       cumulative: signups_cumulative.count,
-      sms_yesterday: sms_signups_yesterday.count,
+      sms_day_before: sms_signups_day_before.count,
       sms_cumulative: sms_signups_cumulative.count,
-      email_yesterday: email_signups_yesterday.count,
+      email_day_before: email_signups_day_before.count,
       email_cumulative: email_signups_cumulative.count,
-      sponsored_yesterday: sponsored_signups_yesterday.count,
+      sponsored_day_before: sponsored_signups_day_before.count,
       sponsored_cumulative: sponsored_signups_cumulative.count
     }
   end
 
 private
 
+  attr_reader :date
+
   def repository
     PerformancePlatform::Repository::SignUp
   end
 
-  def signups_yesterday
-    repository.yesterday
+  def signups_day_before
+    repository.day_before(date)
   end
 
   def signups_cumulative
-    repository.all
+    repository.all(date)
   end
 
-  def sms_signups_yesterday
-    signups_yesterday.self_sign.with_sms
+  def sms_signups_day_before
+    signups_day_before.self_sign.with_sms
   end
 
   def sms_signups_cumulative
     signups_cumulative.self_sign.with_sms
   end
 
-  def email_signups_yesterday
-    signups_yesterday.self_sign.with_email
+  def email_signups_day_before
+    signups_day_before.self_sign.with_email
   end
 
   def email_signups_cumulative
@@ -48,7 +54,7 @@ private
     signups_cumulative.sponsored
   end
 
-  def sponsored_signups_yesterday
-    signups_yesterday.sponsored
+  def sponsored_signups_day_before
+    signups_day_before.sponsored
   end
 end

--- a/lib/performance_platform/presenter/completion_rate.rb
+++ b/lib/performance_platform/presenter/completion_rate.rb
@@ -1,4 +1,8 @@
 class PerformancePlatform::Presenter::CompletionRate
+  def initialize(date: Date.today.to_s)
+    @date = Date.parse(date)
+  end
+
   def present(stats:)
     @stats = stats
     @timestamp = generate_timestamp
@@ -18,8 +22,10 @@ class PerformancePlatform::Presenter::CompletionRate
 
 private
 
+  attr_reader :date
+
   def generate_timestamp
-    "#{Date.today}T00:00:00+00:00"
+    "#{date}T00:00:00+00:00"
   end
 
   def as_hash(count, channel, stage)

--- a/lib/performance_platform/presenter/volumetrics.rb
+++ b/lib/performance_platform/presenter/volumetrics.rb
@@ -1,4 +1,8 @@
 class PerformancePlatform::Presenter::Volumetrics
+  def initialize(date: Date.today.to_s)
+    @date = Date.parse(date)
+  end
+
   def present(stats:)
     @stats = stats
     @timestamp = generate_timestamp
@@ -6,18 +10,20 @@ class PerformancePlatform::Presenter::Volumetrics
     {
       metric_name: stats[:metric_name],
       payload: [
-        as_hash(stats[:yesterday], stats[:cumulative], 'all-sign-ups'),
-        as_hash(stats[:sms_yesterday], stats[:sms_cumulative], 'sms-sign-ups'),
-        as_hash(stats[:email_yesterday], stats[:email_cumulative], 'email-sign-ups'),
-        as_hash(stats[:sponsored_yesterday], stats[:sponsored_cumulative], 'sponsor-sign-ups'),
+        as_hash(stats[:day_before], stats[:cumulative], 'all-sign-ups'),
+        as_hash(stats[:sms_day_before], stats[:sms_cumulative], 'sms-sign-ups'),
+        as_hash(stats[:email_day_before], stats[:email_cumulative], 'email-sign-ups'),
+        as_hash(stats[:sponsored_day_before], stats[:sponsored_cumulative], 'sponsor-sign-ups'),
       ]
     }
   end
 
 private
 
+  attr_reader :date
+
   def generate_timestamp
-    "#{Date.today - 1}T00:00:00+00:00"
+    "#{date - 1}T00:00:00+00:00"
   end
 
   def as_hash(count, cumulative_count, channel)

--- a/lib/performance_platform/repository/sign_up.rb
+++ b/lib/performance_platform/repository/sign_up.rb
@@ -1,11 +1,11 @@
 class PerformancePlatform::Repository::SignUp < Sequel::Model(:userdetails)
   dataset_module do
-    def all
-      where(Sequel.lit("date(created_at) <= '#{Date.today - 1}'"))
+    def all(date)
+      where(Sequel.lit("date(created_at) <= '#{date - 1}'"))
     end
 
-    def yesterday
-      where(Sequel.lit("date(created_at) = '#{Date.today - 1}'"))
+    def day_before(date)
+      where(Sequel.lit("date(created_at) = '#{date - 1}'"))
     end
 
     def self_sign
@@ -24,8 +24,8 @@ class PerformancePlatform::Repository::SignUp < Sequel::Model(:userdetails)
       where(Sequel.like(:contact, '%@%'))
     end
 
-    def last_week
-      where(Sequel.lit("date(created_at) BETWEEN '#{Date.today - 14}' AND '#{Date.today - 7}'"))
+    def week_before(date)
+      where(Sequel.lit("date(created_at) BETWEEN '#{date - 14}' AND '#{date - 7}'"))
     end
 
     def with_successful_login

--- a/spec/unit/lib/performance_platform/gateway/volumetrics_spec.rb
+++ b/spec/unit/lib/performance_platform/gateway/volumetrics_spec.rb
@@ -8,16 +8,16 @@ describe PerformancePlatform::Gateway::Volumetrics do
   context 'given no signups' do
     it 'returns stats with zero signups' do
       expect(subject.fetch_stats).to eq(
-        yesterday: 0,
+        day_before: 0,
         cumulative: 0,
-        sms_yesterday: 0,
+        sms_day_before: 0,
         sms_cumulative: 0,
         metric_name: 'volumetrics',
         period: 'day',
-        email_yesterday: 0,
+        email_day_before: 0,
         email_cumulative: 0,
         sponsored_cumulative: 0,
-        sponsored_yesterday: 0
+        sponsored_day_before: 0
       )
     end
   end
@@ -28,7 +28,7 @@ describe PerformancePlatform::Gateway::Volumetrics do
     end
 
     it 'compares sign up creation date by date only' do
-      expect(subject.fetch_stats[:yesterday]).to eq(1)
+      expect(subject.fetch_stats[:day_before]).to eq(1)
     end
   end
 
@@ -40,7 +40,7 @@ describe PerformancePlatform::Gateway::Volumetrics do
     end
 
     it 'returns signups for yesterday' do
-      expect(subject.fetch_stats[:yesterday]).to eq(3)
+      expect(subject.fetch_stats[:day_before]).to eq(3)
     end
 
     it 'returns same cumulative number of signups' do
@@ -58,7 +58,7 @@ describe PerformancePlatform::Gateway::Volumetrics do
     end
 
     it 'returns zero signups 5 signups for yesterday' do
-      expect(subject.fetch_stats[:yesterday]).to eq(5)
+      expect(subject.fetch_stats[:day_before]).to eq(5)
     end
 
     it 'returns zero signups 6 signups cumulative' do
@@ -74,7 +74,7 @@ describe PerformancePlatform::Gateway::Volumetrics do
     end
 
     it 'returns zero signups for yesterday' do
-      expect(subject.fetch_stats[:yesterday]).to eq(0)
+      expect(subject.fetch_stats[:day_before]).to eq(0)
     end
 
     it 'returns zero signups cumulative' do
@@ -111,7 +111,7 @@ describe PerformancePlatform::Gateway::Volumetrics do
     end
 
     it 'counts all of them against yesterdays signups' do
-      expect(subject.fetch_stats[:yesterday]).to eq(3)
+      expect(subject.fetch_stats[:day_before]).to eq(3)
     end
 
     it 'calculates SMS cumulative signups' do
@@ -119,7 +119,7 @@ describe PerformancePlatform::Gateway::Volumetrics do
     end
 
     it 'calculates SMS yesterdays signups' do
-      expect(subject.fetch_stats[:sms_yesterday]).to eq(1)
+      expect(subject.fetch_stats[:sms_day_before]).to eq(1)
     end
 
     it 'calculates email cumulative signups' do
@@ -127,7 +127,7 @@ describe PerformancePlatform::Gateway::Volumetrics do
     end
 
     it 'calculates email yesterdays signups' do
-      expect(subject.fetch_stats[:email_yesterday]).to eq(2)
+      expect(subject.fetch_stats[:email_day_before]).to eq(2)
     end
   end
 
@@ -153,7 +153,7 @@ describe PerformancePlatform::Gateway::Volumetrics do
     end
 
     it 'counts them against yesterdays signups' do
-      expect(subject.fetch_stats[:yesterday]).to eq(1)
+      expect(subject.fetch_stats[:day_before]).to eq(1)
     end
 
     it 'counts them against SMS cumulative signups' do
@@ -161,7 +161,7 @@ describe PerformancePlatform::Gateway::Volumetrics do
     end
 
     it 'counts them against SMS yesterdays signups' do
-      expect(subject.fetch_stats[:sms_yesterday]).to eq(1)
+      expect(subject.fetch_stats[:sms_day_before]).to eq(1)
     end
   end
 
@@ -187,7 +187,7 @@ describe PerformancePlatform::Gateway::Volumetrics do
     end
 
     it 'counts them against yesterdays signups' do
-      expect(subject.fetch_stats[:yesterday]).to eq(1)
+      expect(subject.fetch_stats[:day_before]).to eq(1)
     end
 
     it 'counts them against email cumulative signups' do
@@ -195,7 +195,7 @@ describe PerformancePlatform::Gateway::Volumetrics do
     end
 
     it 'counts them against email signups yesterday' do
-      expect(subject.fetch_stats[:email_yesterday]).to eq(1)
+      expect(subject.fetch_stats[:email_day_before]).to eq(1)
     end
   end
 
@@ -221,7 +221,35 @@ describe PerformancePlatform::Gateway::Volumetrics do
     end
 
     it 'counts one of them as sponsored sign up yesterday' do
-      expect(subject.fetch_stats[:sponsored_yesterday]).to eq(1)
+      expect(subject.fetch_stats[:sponsored_day_before]).to eq(1)
+    end
+  end
+
+  context 'Date override' do
+    subject { described_class.new(date: '2018-08-10') }
+
+    before do
+      user_repository.create(
+        username: 'Email',
+        contact: 'foo@bar.com',
+        sponsor: 'sponsor@bar.com',
+        created_at: '2018-08-09'
+        )
+
+      user_repository.create(
+        username: 'SMS',
+        contact: 'foo@baz.com',
+        sponsor: 'sponsor@baz.com',
+        created_at: '2018-08-29'
+        )
+    end
+
+    it 'counts both of them to cumulative number of sponsored sign ups' do
+      expect(subject.fetch_stats[:sponsored_cumulative]).to eq(1)
+    end
+
+    it 'counts one of them as sponsored sign up yesterday' do
+      expect(subject.fetch_stats[:sponsored_day_before]).to eq(1)
     end
   end
 end

--- a/spec/unit/lib/performance_platform/presenter/completion_rate_spec.rb
+++ b/spec/unit/lib/performance_platform/presenter/completion_rate_spec.rb
@@ -1,0 +1,58 @@
+require 'timecop'
+
+describe PerformancePlatform::Presenter::CompletionRate do
+  before do
+    Timecop.freeze(Date.parse('04-04-2018'))
+  end
+
+  after do
+    Timecop.return
+  end
+
+  let(:stats) do
+    {
+      period: 'week',
+      metric_name: 'completion-rate',
+      sms_registered: 0,
+      sms_logged_in: 0,
+      email_registered: 0,
+      email_logged_in: 0,
+      sponsor_registered: 0,
+      sponsor_logged_in: 0
+    }
+  end
+
+  it 'presents the correct ID' do
+    expected_id = 'MjAxOC0wNC0wNFQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2NvbXBsZXRpb24tcmF0ZXN0YXJ0c21z'
+    expect(subject.present(stats: stats)[:payload].first).to include(
+      _id: expected_id,
+      _timestamp: '2018-04-04T00:00:00+00:00'
+    )
+  end
+
+  context 'Given a date override' do
+    subject { described_class.new(date: '04-04-2018') }
+
+    context 'Same date as today' do
+      it 'does not change the identifier' do
+        expected_id = 'MjAxOC0wNC0wNFQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2NvbXBsZXRpb24tcmF0ZXN0YXJ0c21z'
+        expect(subject.present(stats: stats)[:payload].first).to include(
+          _id: expected_id,
+          _timestamp: '2018-04-04T00:00:00+00:00'
+        )
+      end
+    end
+
+    context 'Given a different date to override' do
+      subject { described_class.new(date: '05-04-2018') }
+
+      it 'changes the identifier' do
+        expected_id = 'MjAxOC0wNC0wNVQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2NvbXBsZXRpb24tcmF0ZXN0YXJ0c21z'
+        expect(subject.present(stats: stats)[:payload].first).to include(
+          _id: expected_id,
+          _timestamp: '2018-04-05T00:00:00+00:00'
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/lib/performance_platform/presenter/volumetrics_spec.rb
+++ b/spec/unit/lib/performance_platform/presenter/volumetrics_spec.rb
@@ -1,0 +1,60 @@
+require 'timecop'
+
+describe PerformancePlatform::Presenter::Volumetrics do
+  before do
+    Timecop.freeze(Date.parse('04-04-2018'))
+  end
+
+  after do
+    Timecop.return
+  end
+
+  let(:stats) do
+    {
+      period: 'day',
+      metric_name: 'volumetrics',
+      day_before: 0,
+      cumulative: 0,
+      sms_day_before: 0,
+      sms_cumulative: 0,
+      email_day_before: 0,
+      email_cumulative: 0,
+      sponsored_day_before: 0,
+      sponsored_cumulative: 0
+    }
+  end
+
+  it 'presents the correct ID' do
+    expected_id = 'MjAxOC0wNC0wM1QwMDowMDowMCswMDowMGdvdi13aWZpZGF5dm9sdW1ldHJpY3NhbGwtc2lnbi11cHM='
+    expect(subject.present(stats: stats)[:payload].first).to include(
+      _id: expected_id,
+      _timestamp: '2018-04-03T00:00:00+00:00'
+    )
+  end
+
+  context 'Given a date override' do
+    subject { described_class.new(date: '04-04-2018') }
+
+    context 'Same date as today' do
+      it 'does not change the identifier' do
+        expected_id = 'MjAxOC0wNC0wM1QwMDowMDowMCswMDowMGdvdi13aWZpZGF5dm9sdW1ldHJpY3NhbGwtc2lnbi11cHM='
+        expect(subject.present(stats: stats)[:payload].first).to include(
+          _id: expected_id,
+          _timestamp: '2018-04-03T00:00:00+00:00'
+        )
+      end
+    end
+
+    context 'Given a different date to override' do
+      subject { described_class.new(date: '05-04-2018') }
+
+      it 'changes the identifier' do
+        expected_id = 'MjAxOC0wNC0wNFQwMDowMDowMCswMDowMGdvdi13aWZpZGF5dm9sdW1ldHJpY3NhbGwtc2lnbi11cHM='
+        expect(subject.present(stats: stats)[:payload].first).to include(
+          _id: expected_id,
+          _timestamp: '2018-04-04T00:00:00+00:00'
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/lib/performance_platform/use_case/send_performance_report_spec.rb
+++ b/spec/unit/lib/performance_platform/use_case/send_performance_report_spec.rb
@@ -46,13 +46,13 @@ describe PerformancePlatform::UseCase::SendPerformanceReport do
       {
         metric_name: 'volumetrics',
         period: 'day',
-        yesterday: 12,
+        day_before: 12,
         cumulative: 24,
-        sms_yesterday: 2,
+        sms_day_before: 2,
         sms_cumulative: 3,
-        email_yesterday: 10,
+        email_day_before: 10,
         email_cumulative: 21,
-        sponsored_yesterday: 7,
+        sponsored_day_before: 7,
         sponsored_cumulative: 9
       }
     }

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -1,11 +1,12 @@
 require 'logger'
 logger = Logger.new(STDOUT)
 
-task :publish_daily_statistics do
-  logger.info('publishing daily statistics')
+task :publish_daily_statistics, :date do |_, args|
+  args.with_defaults(date: Date.today.to_s)
+  logger.info("publishing daily statistics with #{args}")
   performance_gateway = PerformancePlatform::Gateway::PerformanceReport.new
-  volumetrics_gateway = PerformancePlatform::Gateway::Volumetrics.new
-  volumetrics_presenter = PerformancePlatform::Presenter::Volumetrics.new
+  volumetrics_gateway = PerformancePlatform::Gateway::Volumetrics.new(date: args[:date])
+  volumetrics_presenter = PerformancePlatform::Presenter::Volumetrics.new(date: args[:date])
 
   PerformancePlatform::UseCase::SendPerformanceReport.new(
     stats_gateway: volumetrics_gateway,
@@ -13,10 +14,11 @@ task :publish_daily_statistics do
   ).execute(presenter: volumetrics_presenter)
 end
 
-task :publish_weekly_statistics do
-  logger.info('publishing weekly statistics')
+task :publish_weekly_statistics, :date do |_, args|
+  args.with_defaults(date: Date.today.to_s)
+  logger.info("publishing weekly statistics #{date}")
   performance_gateway = PerformancePlatform::Gateway::PerformanceReport.new
-  completion_rate_gateway = PerformancePlatform::Gateway::CompletionRate.new
+  completion_rate_gateway = PerformancePlatform::Gateway::CompletionRate.new(date: args[:date])
   completion_rate_presenter = PerformancePlatform::Presenter::CompletionRate.new
 
   PerformancePlatform::UseCase::SendPerformanceReport.new(


### PR DESCRIPTION
Some of the performance statistics are not being reported.
We suspect this is a bug with our configuration of ECS scheduled tasks.
This needs to be fixed, but for now provide a way to override the date
so that we can easily backfil missing data on the performance platform.