### PR TITLE
Update Readme with Performance Platform details

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,28 @@ These get stored and sent to the user.
 * `POST /user-signup/email-notification` - AWS SES incoming email notifications
 * `POST /user-signup/sms-notification` - Firetext incoming SMS notifications
 
+## Performance Platform
+
+This application sends statistics to the [Performance Platform](https://www.gov.uk/performance/govwifi) for volumetrics and completion rates via a Rake task.  This Rake task is triggered by an ECS scheduled task.
+
+### Send statistics manually
+
+You can trigger statistics to be sent manually by running the command below locally.
+Ensure that your ~/.aws/credentials is set up correctly.
+Populate the date argument to the Rake task with the date that you want to send the statistics for.
+
+#### Volumetrics
+
+```shell
+aws ecs run-task --cluster api-cluster --task-definition user-signup-api-task --count 1 --overrides "{ \"containerOverrides\": [{ \"name\": \"user-signup\", \"command\": [\"bundle\", \"exec\", \"rake\", \"publish_daily_statistics['2018-05-03']\"] }] }" --region eu-west-2
+```
+
+#### Completion Rate
+
+```shell
+aws ecs run-task --cluster api-cluster --task-definition user-signup-api-task --count 1 --overrides "{ \"containerOverrides\": [{ \"name\": \"user-signup\", \"command\": [\"bundle\", \"exec\", \"rake\", \"publish_weekly_statistics['2018-05-03']\"] }] }" --region eu-west-2
+```
+
 ### Dependencies
 
 * [GOV.UK Notify](https://www.notifications.service.gov.uk/) - used to send outgoing emails and SMS replies

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -19,7 +19,7 @@ task :publish_weekly_statistics, :date do |_, args|
   logger.info("publishing weekly statistics #{date}")
   performance_gateway = PerformancePlatform::Gateway::PerformanceReport.new
   completion_rate_gateway = PerformancePlatform::Gateway::CompletionRate.new(date: args[:date])
-  completion_rate_presenter = PerformancePlatform::Presenter::CompletionRate.new
+  completion_rate_presenter = PerformancePlatform::Presenter::CompletionRate.new(date: args[:date])
 
   PerformancePlatform::UseCase::SendPerformanceReport.new(
     stats_gateway: completion_rate_gateway,


### PR DESCRIPTION
Ensure instructions for backfilling performance statistics is in the
README.  Also add override argument to rake task for weekly statistics