### PR TITLE
Fix syntax error with weekly statistics

### DIFF
--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -16,7 +16,7 @@ end
 
 task :publish_weekly_statistics, :date do |_, args|
   args.with_defaults(date: Date.today.to_s)
-  logger.info("publishing weekly statistics #{date}")
+  logger.info("publishing weekly statistics #{args}")
   performance_gateway = PerformancePlatform::Gateway::PerformanceReport.new
   completion_rate_gateway = PerformancePlatform::Gateway::CompletionRate.new(date: args[:date])
   completion_rate_presenter = PerformancePlatform::Presenter::CompletionRate.new(date: args[:date])


### PR DESCRIPTION
We allowed backfilling data for the performance platform.
We log when it runs, and this was trying to print a variable that
doesn't exist.