### PR TITLE
Send Rake errors to Sentry

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,14 +1,2 @@
-RACK_ENV = ENV['RACK_ENV'] ||= 'development'
-
-if %w[production staging].include?(RACK_ENV)
-  require 'raven'
-
-  Raven.configure do |config|
-    config.dsn = ENV['SENTRY_DSN']
-  end
-
-  use Raven::Rack
-end
-
 require './app'
 run App

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,5 +1,13 @@
 require 'sequel'
 
+if %w[production staging].include?(ENV['RACK_ENV'])
+  require 'raven'
+
+  Raven.configure do |config|
+    config.dsn = ENV['SENTRY_DSN']
+  end
+end
+
 DB = Sequel.connect(
   adapter: 'mysql2',
   host: ENV.fetch('DB_HOSTNAME'),


### PR DESCRIPTION
Currently we get no errors sent to Sentry.
This requires it and will send any Rake task exceptions.