### PR TITLE
Always perform 'make stop' in jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,6 +63,10 @@ pipeline {
     success {
       setBuildStatus("Build successful", "SUCCESS");
     }
+
+    cleanup {
+      sh 'make stop'
+    }
   }
 }
 


### PR DESCRIPTION
Ensure that `make stop` is run after every Jenkins CI build. This removes any containers on Jenkins that would otherwise be using a port that the next CI run wants access to.