### PR TITLE
[WIP]: Change reply address from support to do-not-reply

### DIFF
--- a/lib/wifi_user/use_case/email_signup.rb
+++ b/lib/wifi_user/use_case/email_signup.rb
@@ -26,10 +26,15 @@ private
       email_address: email_address,
       template_id: credentials_template_id,
       personalisation: login_details
+      # email_reply_to_id: do_not_reply_template_id
     )
   end
 
   def credentials_template_id
     YAML.load_file("config/#{ENV['RACK_ENV']}.yml").fetch('notify_email_template_ids').fetch('self_signup_credentials')
   end
+
+  # def do_not_reply_template_id
+  #   YAML.load_file("config/#{ENV['RACK_ENV']}.yml").fetch('notify_email_template_ids').fetch('do_not_reply_credentials')
+  # end
 end

--- a/spec/unit/lib/wifi_user/use_cases/email_signup_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/email_signup_spec.rb
@@ -36,15 +36,24 @@ describe WifiUser::UseCase::EmailSignup do
     context 'in the production environment' do
       let(:environment) { 'production' }
       let(:notify_template_id) { 'f18708c0-e857-4f62-b5f3-8f0c75fc2fdb' }
+      let(:created_contact) { 'adrian@gov.uk' }
+      let(:username) { 'MockUsername' }
+      let(:password) { 'MockPassword' }
+      let(:template_finder) { double(execute: notify_template_id) }
 
       context 'given an email address without a name part' do
-        let(:created_contact) { 'adrian@gov.uk' }
-        let(:username) { 'MockUsername' }
-        let(:password) { 'MockPassword' }
 
         it 'sends email to Notify with the new credentials' do
           subject.execute(contact: created_contact)
           expect(notify_email_stub).to have_been_requested.times(1)
+        end
+      end
+
+      context 'bounces reply emails' do
+        it 'with content' do
+          response = subject.execute(contact: created_contact)
+          expect(template_finder).to receive(response)
+          pp response
         end
       end
     end

--- a/spec/unit/lib/wifi_user/use_cases/email_signup_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/email_signup_spec.rb
@@ -28,6 +28,10 @@ describe WifiUser::UseCase::EmailSignup do
 
       notify_email_stub
 
+      # allow(notify_email_stub).to receive(:execute)
+      # .with(body: notify_email_request)
+      # .and_return(body: notify_email_request)
+
       allow(user_model).to receive(:generate)
         .with(contact: created_contact)
         .and_return(username: username, password: password)
@@ -39,7 +43,7 @@ describe WifiUser::UseCase::EmailSignup do
       let(:created_contact) { 'adrian@gov.uk' }
       let(:username) { 'MockUsername' }
       let(:password) { 'MockPassword' }
-      let(:template_finder) { double(execute: notify_template_id) }
+      # let(:template_finder) { double(execute: notify_template_id) }
 
       context 'given an email address without a name part' do
 
@@ -51,9 +55,8 @@ describe WifiUser::UseCase::EmailSignup do
 
       context 'bounces reply emails' do
         it 'with content' do
-          response = subject.execute(contact: created_contact)
-          expect(template_finder).to receive(response)
-          pp response
+          subject.execute(contact: created_contact)
+          expect(notify_email_stub).to receive(:execute).and_return(body: "")
         end
       end
     end


### PR DESCRIPTION
- Checking notify documentation has given a hint in the right direction in implementing a change of reply address when the end user clicks reply to a sign-up notification email. This would involved adding an additional address and using the generated token in the email sign up use-case.

- In pursuit of this, attempts were made to create a suitable test. The thought process was to create a test that returned or demonstrated that a particular field in the email template e.g. email address, was present in the request. From here, it could be determined how to implement the change in the reply addresses in a more confident manner. 

- Suggestions would be [greatly] appreciated for methods to test an instance of the user trying to create a reply email and checking that the reply email given is the desired one.