### PR TITLE
Match ruby version in .ruby-version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5-alpine
+FROM ruby:2.5.1-alpine
 ARG BUNDLE_INSTALL_CMD
 ENV RACK_ENV=development
 ENV WORD_LIST_FILE='./tmp/wordlist'


### PR DESCRIPTION
**What**

Match the ruby version in the Dockerfile to the one specified in `.ruby-version`

**Why**

Dockerfile was only referencing `major`.`minor` version of ruby which meant it was pulling in the latest version of 2.5.x (2.5.3), where as the solution is bound to 2.5.1. This causes `make build` to fail with the following error:

```shell
Your Ruby version is 2.5.3, but your Gemfile specified 2.5.1
ERROR: Service 'app' failed to build: The command '/bin/sh -c apk --update --upgrade add build-base mysql-dev &&   bundle check || ${BUNDLE_INSTALL_CMD} &&   apk del build-base &&   find / -type f -iname \*.apk-new -delete &&   rm -rf /var/cache/apk/*' returned a non-zero code: 18
make: *** [build] Error 1
```


