### PR TITLE
Ensures app always waits for db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,9 @@ build:
 
 serve:
 	$(MAKE) build
-	docker-compose up -d
+	docker-compose up -d db
+	./mysql/bin/wait_for_mysql
+	docker-compose up
 
 lint:
 	$(MAKE) build

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ serve:
 	$(MAKE) build
 	docker-compose up -d db
 	./mysql/bin/wait_for_mysql
-	docker-compose up
+	docker-compose up -d
 
 lint:
 	$(MAKE) build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,8 @@ services:
       DB_HOSTNAME: db
       RACK_ENV: development
       AUTHORISED_EMAIL_DOMAINS_REGEX: "\\.gov\\.uk$$"
+    depends_on:
+      - db
+    ports:
+      - "8080:8080"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,3 @@ services:
       AUTHORISED_EMAIL_DOMAINS_REGEX: "\\.gov\\.uk$$"
     depends_on:
       - db
-    ports:
-      - "8080:8080"
-


### PR DESCRIPTION
**What**

Uses `wait_for_mysql` to delay starting up the `app` service when running `make serve`

**Why**

`app` frequently start up before `db` is ready causing it to exit early.