### PR TITLE
Autodeploy to staging, one-click deploy to production

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,6 @@ def deploy_production() {
   try {
     timeout(time: 5, unit: 'MINUTES') {
       input "Do you want to deploy to production?"
-
       deploy('production')
     }
   } catch(err) { // timeout reached or input false
@@ -131,6 +130,13 @@ def deploy(deploy_environment) {
     )
     appImage.push()
   }
+
+  if(deploy_environment == 'production') { deploy_environment = 'wifi' }
+
+  cluster_name = "${deploy_environment}-api-cluster"
+  service_name = "user-signup-api-service-${deploy_environment}"
+
+  sh("aws ecs update-service --force-new-deployment --cluster ${cluster_name} --service ${service_name} --region eu-west-2")
 }
 
 def publishStableTag() {


### PR DESCRIPTION
Similar to https://github.com/alphagov/govwifi-authentication-api/pull/37 and https://github.com/alphagov/govwifi-logging-api/pull/75, again only for a single region, so a little simpler.

Tested this out using Jenkins' build-on-demand, is working fine.