### PR TITLE
Rename delete_users to delete_inactive_users

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ aws ecs run-task --cluster api-cluster --task-definition user-signup-api-task --
 aws ecs run-task --cluster api-cluster --task-definition user-signup-api-task --count 1 --overrides "{ \"containerOverrides\": [{ \"name\": \"user-signup\", \"command\": [\"bundle\", \"exec\", \"rake\", \"publish_weekly_statistics['2018-05-03']\"] }] }" --region eu-west-2
 ```
 
+## GDPR
+
+#### Inactive User Deletion
+
+Any user who has not logged into GovWifi for more than 12 months is considered inactive.
+
+We have a Rake task that runs daily with ECS Scheduled tasks to ensure this happens.
+
+```shell
+bundle exec rake delete_inactive_users
+```
+
 ### Dependencies
 
 * [GOV.UK Notify](https://www.notifications.service.gov.uk/) - used to send outgoing emails and SMS replies

--- a/tasks/gdpr/user_deletion.rb
+++ b/tasks/gdpr/user_deletion.rb
@@ -1,7 +1,7 @@
 require 'logger'
 logger = Logger.new(STDOUT)
 
-task :delete_users do
+task :delete_inactive_users do
   user_details_gateway = Gdpr::Gateway::Userdetails.new
 
   Gdpr::UseCase::DeleteInactiveUsers.new(user_details_gateway: user_details_gateway).execute


### PR DESCRIPTION
It is not obvious, from the name that this is a safe operation and
only removes users to keep use GDPR compliant