### PR TITLE
only bind ports in development

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -4,3 +4,5 @@ services:
   app:
     volumes:
     - ".:/usr/src/app"
+    ports:
+      - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: govwifi_test
-    ports:
-      - "13306:3306"
+    expose:
+      - "3306"
 
   app:
     build: .
@@ -18,7 +18,7 @@ services:
       DB_HOSTNAME: db
       RACK_ENV: development
       AUTHORISED_EMAIL_DOMAINS_REGEX: "\\.gov\\.uk$$"
-    ports:
-        - "8080:8080"
+    expose:
+        - "8080"
     depends_on:
       - db


### PR DESCRIPTION
We only want to bind ports while in development, to avoid doing it for in jenkins.

This will allow us to run the tests in parallel