### PR TITLE
Use new user signup whitelist

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ services:
       DB_USER: root
       DB_HOSTNAME: db
       RACK_ENV: development
-      AUTHORISED_EMAIL_DOMAINS_REGEX: "\\.gov\\.uk$$"
+      S3_SIGNUP_WHITELIST_OBJECT_KEY: 'somefile'
+      S3_SIGNUP_WHITELIST_BUCKET: 'somebucket'
     expose:
         - "8080"
     depends_on:

--- a/lib/common/email_address.rb
+++ b/lib/common/email_address.rb
@@ -1,9 +1,0 @@
-class Common::EmailAddress
-  def self.authorised_email_domain?(from_address)
-    authorised_email_domains_regex.match?(from_address)
-  end
-
-  def self.authorised_email_domains_regex
-    Regexp.new(ENV.fetch('AUTHORISED_EMAIL_DOMAINS_REGEX'), Regexp::IGNORECASE)
-  end
-end

--- a/lib/wifi_user/use_case/check_if_whitelisted_email.rb
+++ b/lib/wifi_user/use_case/check_if_whitelisted_email.rb
@@ -1,0 +1,21 @@
+module WifiUser
+  module UseCases
+    class CheckIfWhitelistedEmail
+      def initialize(gateway:)
+        @email_regex_gateway = gateway
+      end
+
+      def execute(email)
+        result = email_regex_gateway.fetch
+
+        pattern = Regexp.new(result, Regexp::IGNORECASE)
+
+        { success: email.to_s.match?(pattern) }
+      end
+
+    private
+
+      attr_reader :email_regex_gateway
+    end
+  end
+end

--- a/lib/wifi_user/use_case/sns_notification_handler.rb
+++ b/lib/wifi_user/use_case/sns_notification_handler.rb
@@ -39,7 +39,13 @@ private
     logger.info("Handling signup request from #{from_address}")
 
     ::WifiUser::UseCase::EmailSignup
-      .new(user_model: WifiUser::Repository::User.new)
+      .new(
+        user_model: WifiUser::Repository::User.new,
+        s3_gateway: Common::Gateway::S3ObjectFetcher.new(
+          bucket: ENV.fetch('S3_SIGNUP_WHITELIST_BUCKET'),
+          key: ENV.fetch('S3_SIGNUP_WHITELIST_OBJECT_KEY')
+        )
+      )
       .execute(contact: from_address)
   end
 

--- a/lib/wifi_user/use_case/sns_notification_handler.rb
+++ b/lib/wifi_user/use_case/sns_notification_handler.rb
@@ -38,15 +38,15 @@ private
     from_address = ses_notification['mail']['commonHeaders']['from'][0]
     logger.info("Handling signup request from #{from_address}")
 
-    ::WifiUser::UseCase::EmailSignup
-      .new(
-        user_model: WifiUser::Repository::User.new,
-        s3_gateway: Common::Gateway::S3ObjectFetcher.new(
+    ::WifiUser::UseCase::EmailSignup.new(
+      user_model: WifiUser::Repository::User.new,
+      whitelist_checker: WifiUser::UseCases::CheckIfWhitelistedEmail.new(
+        gateway: Common::Gateway::S3ObjectFetcher.new(
           bucket: ENV.fetch('S3_SIGNUP_WHITELIST_BUCKET'),
           key: ENV.fetch('S3_SIGNUP_WHITELIST_OBJECT_KEY')
         )
       )
-      .execute(contact: from_address)
+    ).execute(contact: from_address)
   end
 
   def handle_sponsor_request(ses_notification)
@@ -58,8 +58,11 @@ private
     email_fetcher = Common::Gateway::S3ObjectFetcher.new(bucket: action['bucketName'], key: action['objectKey'])
     sponsee_extractor = WifiUser::UseCase::EmailSponseesExtractor.new(email_fetcher: email_fetcher)
 
-    ::WifiUser::UseCase::SponsorUsers
-      .new(user_model: WifiUser::Repository::User.new)
-      .execute(sponsee_extractor.execute, from_address)
+    ::WifiUser::UseCase::SponsorUsers.new(
+      user_model: WifiUser::Repository::User.new,
+      whitelist_checker: WifiUser::UseCases::CheckIfWhitelistedEmail.new(
+        gateway: email_fetcher
+      )
+    ).execute(sponsee_extractor.execute, from_address)
   end
 end

--- a/lib/wifi_user/use_case/sponsor_users.rb
+++ b/lib/wifi_user/use_case/sponsor_users.rb
@@ -1,28 +1,26 @@
 class WifiUser::UseCase::SponsorUsers
-  def initialize(user_model:, s3_gateway:)
+  def initialize(user_model:, whitelist_checker:, logger: Logger.new(STDOUT))
+    @logger = logger
     @user_model = user_model
-    @s3_gateway = s3_gateway
+    @whitelist_checker = whitelist_checker
     @contact_sanitiser = WifiUser::UseCase::ContactSanitiser.new
   end
 
   def execute(unsanitised_sponsees, sponsor)
     sponsor_address = Mail::Address.new(sponsor).address
 
-    return unless authorised_email_domain?(sponsor_address)
-
-    sponsees = sanitise_sponsees(unsanitised_sponsees)
-    invite_sponsees(sponsor, sponsor_address, sponsees)
-    send_confirmation_email(sponsor_address, sponsees)
+    if whitelist_checker.execute(sponsor_address)[:success]
+      sponsees = sanitise_sponsees(unsanitised_sponsees)
+      invite_sponsees(sponsor, sponsor_address, sponsees)
+      send_confirmation_email(sponsor_address, sponsees)
+    else
+      logger.info("Unsuccessful sponsor signup attempt: #{sponsor_address}")
+    end
   end
 
 private
 
-  attr_reader :user_model, :contact_sanitiser, :s3_gateway
-
-  def authorised_email_domain?(email)
-    regex = Regexp.new(s3_gateway.fetch, Regexp::IGNORECASE)
-    regex.match?(email)
-  end
+  attr_reader :user_model, :contact_sanitiser, :whitelist_checker, :logger
 
   def sanitise_sponsees(contacts)
     contacts.map { |contact| contact_sanitiser.execute(contact) }.compact.uniq

--- a/spec/acceptance/email_notification_spec.rb
+++ b/spec/acceptance/email_notification_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe App do
-  before { ENV['AUTHORISED_EMAIL_DOMAINS_REGEX'] = '.gov.uk$' }
-
   describe 'POSTing a Notification to /user-signup/email-notification' do
     let(:bucket_name) { 'stub-bucket-name' }
     let(:object_key) { 'stub-object-key' }

--- a/spec/unit/lib/wifi_user/use_cases/check_if_whitelisted_email_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/check_if_whitelisted_email_spec.rb
@@ -1,0 +1,35 @@
+describe WifiUser::UseCases::CheckIfWhitelistedEmail do
+  subject { described_class.new(gateway: regex_gateway_stub) }
+  let(:regex_gateway_stub) { double(fetch: '^.*@(aaa\.uk)$') }
+
+  context 'given a whitelisted email' do
+    it 'accepts an address matching the regex' do
+      result = subject.execute('someone@aaa.uk')
+      expect(result).to eq(success: true)
+    end
+
+    it 'accepts an address matching the regex regardless of case' do
+      result = subject.execute('SOMEONE@AAA.UK')
+      expect(result).to eq(success: true)
+    end
+  end
+
+  context 'given a non-whitelisted email' do
+    it 'rejects an address not matching the regex' do
+      result = subject.execute('someone@bbb.uk')
+      expect(result).to eq(success: false)
+    end
+  end
+
+  context 'given an invalid email' do
+    it 'rejects an empty email address' do
+      result = subject.execute('')
+      expect(result).to eq(success: false)
+    end
+
+    it 'rejects a nil address' do
+      result = subject.execute(nil)
+      expect(result).to eq(success: false)
+    end
+  end
+end

--- a/spec/unit/lib/wifi_user/use_cases/email_signup_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/email_signup_spec.rb
@@ -1,11 +1,11 @@
 describe WifiUser::UseCase::EmailSignup do
   let(:user_model) { instance_double(WifiUser::Repository::User) }
-  let(:s3_gateway) { double(fetch: '.gov.uk$') }
+  let(:whitelist_checker) { double(execute: { success: true }) }
 
   subject do
     described_class.new(
       user_model: user_model,
-      s3_gateway: s3_gateway
+      whitelist_checker: whitelist_checker
     )
   end
 
@@ -87,6 +87,7 @@ describe WifiUser::UseCase::EmailSignup do
       end
 
       context 'given an email address with a non-gov domain' do
+        let(:whitelist_checker) { double(execute: { success: false }) }
         let(:created_contact) { 'irrelevant@somewhere.uk' }
         let(:username) { 'irrelevant' }
         let(:password) { 'irrelephant' }

--- a/spec/unit/lib/wifi_user/use_cases/email_signup_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/email_signup_spec.rb
@@ -1,6 +1,13 @@
 describe WifiUser::UseCase::EmailSignup do
   let(:user_model) { instance_double(WifiUser::Repository::User) }
-  subject { described_class.new(user_model: user_model) }
+  let(:s3_gateway) { double(fetch: '.gov.uk$') }
+
+  subject do
+    described_class.new(
+      user_model: user_model,
+      s3_gateway: s3_gateway
+    )
+  end
 
   describe 'Using an authorised email domain' do
     let(:notify_email_url) { 'https://api.notifications.service.gov.uk/v2/notifications/email' }

--- a/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
@@ -8,10 +8,18 @@ describe WifiUser::UseCase::SponsorUsers do
   let(:staging_do_not_reply_id) { '45d6b6c4-6a36-47df-b34d-256b8c0d1511' }
 
   let(:user_model) { double(generate: { username: username, password: password }) }
-  subject { described_class.new(user_model: user_model) }
+  let(:s3_gateway) { double(fetch: '.gov.uk$') }
+
+  subject do
+    described_class.new(
+      user_model: user_model,
+      s3_gateway: s3_gateway
+    )
+  end
 
   before do
     ENV['RACK_ENV'] = environment
+    ENV['NOTIFY_API_KEY'] = 'dummy_key-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000'
     stub_request(:post, notify_email_url).to_return(status: 200, body: {}.to_json)
     stub_request(:post, notify_sms_url).to_return(status: 200, body: {}.to_json)
     subject.execute(sponsees, sponsor)

--- a/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
@@ -8,12 +8,12 @@ describe WifiUser::UseCase::SponsorUsers do
   let(:staging_do_not_reply_id) { '45d6b6c4-6a36-47df-b34d-256b8c0d1511' }
 
   let(:user_model) { double(generate: { username: username, password: password }) }
-  let(:s3_gateway) { double(fetch: '.gov.uk$') }
+  let(:whitelist_checker) { double(execute: { success: true }) }
 
   subject do
     described_class.new(
       user_model: user_model,
-      s3_gateway: s3_gateway
+      whitelist_checker: whitelist_checker
     )
   end
 
@@ -156,6 +156,7 @@ describe WifiUser::UseCase::SponsorUsers do
     let(:sponsor) { 'adrian <adrian@fake.uk>' }
     let(:sponsees) { ['adrian@notgov.uk'] }
     let(:do_not_reply_id) { staging_do_not_reply_id }
+    let(:whitelist_checker) { double(execute: { success: false }) }
 
     it 'Does not call user_model#generate' do
       expect(user_model).not_to have_received(:generate)


### PR DESCRIPTION
We made the user signup white list content manageable in the admin.
It publishes a regex to S3.  We can use this regex instead of the
environment variable set previously.