### PR TITLE
Refactor SNSNotificationHandler

### DIFF
--- a/config/test.yml
+++ b/config/test.yml
@@ -1,0 +1,20 @@
+notify_sms_template_ids:
+  credentials: aaa
+  help_menu: bbb
+  generic_help: ccc
+  device_help:
+    android: ddd
+    blackberry: eee
+    mac: fff
+    iphone: ggg
+    windows: hhh
+
+notify_email_template_ids:
+  self_signup_credentials: iii
+  sponsored_credentials: jjj
+  sponsor_confirmation:
+    plural: kkk
+    singular: lll
+    failed: mmm
+
+do_not_reply_email_id: nnn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       RACK_ENV: development
       S3_SIGNUP_WHITELIST_OBJECT_KEY: 'somefile'
       S3_SIGNUP_WHITELIST_BUCKET: 'somebucket'
+      NOTIFY_API_KEY: dummy_key-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000
     expose:
         - "8080"
     depends_on:

--- a/spec/features/app_spec.rb
+++ b/spec/features/app_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe App do
+  describe 'POST /user-signup/sms-notification' do
+    before do
+      stub_request(:post, 'https://api.notifications.service.gov.uk/v2/notifications/sms').
+        with(headers: { 'Content-Type' => 'application/json' })
+        .to_return(status: 200, body: '{"foo":"bar"}')
+    end
+
+    it 'returns 200' do
+      post '/user-signup/sms-notification', source: '000000000', message: 'Go'
+      expect(last_response.body).to eq('')
+      expect(last_response).to be_successful
+    end
+  end
+
+  describe 'POST /user-signup/email-notification' do
+    it 'returns 200' do
+      post '/user-signup/email-notification', '{"Type":"NOOP"}'
+      expect(last_response.body).to eq('')
+      expect(last_response).to be_successful
+    end
+  end
+end

--- a/spec/features/sms_spec.rb
+++ b/spec/features/sms_spec.rb
@@ -7,7 +7,6 @@ describe App do
 
     before do
       ENV['RACK_ENV'] = 'staging'
-      ENV['NOTIFY_API_KEY'] = 'dummy_key-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000'
       stub_request(:post, notify_sms_url).to_return(status: 200, body: {}.to_json)
     end
 

--- a/spec/unit/lib/wifi_user/use_cases/email_signup_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/email_signup_spec.rb
@@ -29,10 +29,7 @@ describe WifiUser::UseCase::EmailSignup do
         .to_return(status: 200, body: {}.to_json)
     end
 
-    let(:notify_api_key) { 'dummy_key-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000' }
-
     before do
-      ENV['NOTIFY_API_KEY'] = notify_api_key
       ENV['RACK_ENV'] = environment
 
       notify_email_stub

--- a/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
@@ -19,7 +19,6 @@ describe WifiUser::UseCase::SponsorUsers do
 
   before do
     ENV['RACK_ENV'] = environment
-    ENV['NOTIFY_API_KEY'] = 'dummy_key-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000'
     stub_request(:post, notify_email_url).to_return(status: 200, body: {}.to_json)
     stub_request(:post, notify_sms_url).to_return(status: 200, body: {}.to_json)
     subject.execute(sponsees, sponsor)


### PR DESCRIPTION
This class is a UseCase with dependencies hardcoded in it, making it
difficult to change.  Inject the SMS and Email handlers and wrap a high
level feature spec around this.

Move NOTIFY_API_KEY to the docker-compose setup as we don't do any
direct assertions against this.