### PR TITLE
Use new email parser in SNS notification handler

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -47,9 +47,12 @@ class App < Sinatra::Base
       whitelist_checker: whitelist_checker
     )
 
+    email_parser = WifiUser::UseCase::ParseEmailRequest.new
+
     WifiUser::UseCase::SnsNotificationHandler.new(
       email_signup_handler: email_signup_handler,
-      sponsor_signup_handler: sponsor_signup_handler
+      sponsor_signup_handler: sponsor_signup_handler,
+      email_parser: email_parser
     ).handle(request)
   end
 

--- a/lib/wifi_user/use_case/parse_email_request.rb
+++ b/lib/wifi_user/use_case/parse_email_request.rb
@@ -9,16 +9,36 @@ class WifiUser::UseCase::ParseEmailRequest
     logger.debug("Processing request: #{parsed_request} with message #{parsed_message}")
 
     {
-      type: parsed_request['Type'],
-      message_id: parsed_message['mail']['messageId'],
-      from_address: parsed_message['mail']['commonHeaders']['from'][0],
-      to_address: parsed_message['mail']['commonHeaders']['to'][0],
-      s3_object_key: parsed_message['receipt']['action']['objectKey'],
-      s3_bucket_name: parsed_message['receipt']['action']['bucketName']
+      type: parsed_request.fetch('Type'),
+      message_id: message_id(parsed_message),
+      from_address: from_address(parsed_message),
+      to_address: to_address(parsed_message),
+      s3_object_key: s3_object_key(parsed_message),
+      s3_bucket_name: s3_bucket_name(parsed_message)
     }
   end
 
 private
 
   attr_reader :logger
+
+  def message_id(request)
+    request.fetch('mail').fetch('messageId')
+  end
+
+  def from_address(request)
+    request.fetch('mail').fetch('commonHeaders').fetch('from').fetch(0)
+  end
+
+  def to_address(request)
+    request.fetch('mail').fetch('commonHeaders').fetch('to').fetch(0)
+  end
+
+  def s3_object_key(request)
+    request.fetch('receipt').fetch('action').fetch('objectKey')
+  end
+
+  def s3_bucket_name(request)
+    request.fetch('receipt').fetch('action').fetch('bucketName')
+  end
 end

--- a/spec/acceptance/email_notification_spec.rb
+++ b/spec/acceptance/email_notification_spec.rb
@@ -2,12 +2,14 @@ RSpec.describe App do
   describe 'POSTing a Notification to /user-signup/email-notification' do
     let(:bucket_name) { 'stub-bucket-name' }
     let(:object_key) { 'stub-object-key' }
+    let(:message_id) { 'some-message-id' }
 
     let(:ses_notification) do
       # Notification format taken from
       # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/receiving-email-notifications-examples.html
       {
         mail: {
+          messageId: message_id,
           commonHeaders: {
             from: [from_address],
             to: [to_address]
@@ -52,6 +54,14 @@ RSpec.describe App do
         post_notification
         expect(last_response.body).to eq('')
       end
+
+      describe 'POSTing a Amazon SES Setup Notification to /user-signup/email-notification' do
+        let(:message_id) { 'AMAZON_SES_SETUP_NOTIFICATION' }
+
+        it 'ignores the message' do
+          expect { post_notification }.to_not(raise_error)
+        end
+      end
     end
 
     describe 'when the Notification is a sponsor' do
@@ -88,20 +98,6 @@ RSpec.describe App do
         post_notification
         expect(sponsor_users).to have_received(:execute)
                                    .with(['a_fantastic_email@example.com'], 'chris@example.com')
-      end
-    end
-
-    describe 'POSTing a Amazon SES Setup Notification to /user-signup/email-notification' do
-      let(:ses_notification) do
-        {
-          mail: {
-            messageId: 'AMAZON_SES_SETUP_NOTIFICATION'
-          }
-        }
-      end
-
-      it 'ignores the message' do
-        expect { post_notification }.to_not(raise_error)
       end
     end
   end


### PR DESCRIPTION
The knowlege of the request is now being dealt with by the email parser.
We now process the entire request before handling it, which forces some
tests to change.
Use fetch instead of square brackets so we can raise a key error instead
of a nomethod error ([] on nil).  This can be rescued and we can short
curcuit execution.  At this point we will log to Cloudwatch.