### PR TITLE
implement basic validation to ensure our SNS handler only deals with notifications

### DIFF
--- a/lib/wifi_user/use_case/sns_notification_handler.rb
+++ b/lib/wifi_user/use_case/sns_notification_handler.rb
@@ -7,6 +7,10 @@ class WifiUser::UseCase::SnsNotificationHandler
   end
 
   def handle(request)
+    if request_invalid?(request)
+      logger.warn("Unexpected request: \n #{request.body.read}")
+      return
+    end
     params = request.body.read
 
     begin
@@ -55,5 +59,17 @@ private
     sponsee_extractor = WifiUser::UseCase::EmailSponseesExtractor.new(email_fetcher: email_fetcher)
 
     sponsor_signup_handler.execute(sponsee_extractor.execute, from_address)
+  end
+
+  def request_invalid?(request)
+    # For now, we only care that the correct header is set to see if we're
+    # actually dealing with a notification.
+    # There is much more that should be in here.
+    !request_valid?(request)
+  end
+
+  def request_valid?(request)
+    request.has_header?('x-amz-sns-message-type') \
+    && request.get_header('x-amz-sns-message-type') == 'Notification'
   end
 end

--- a/lib/wifi_user/use_case/sns_notification_handler.rb
+++ b/lib/wifi_user/use_case/sns_notification_handler.rb
@@ -62,13 +62,14 @@ private
   end
 
   def request_invalid?(request)
-    # For now, we only care that the correct header is set to see if we're
-    # actually dealing with a notification.
-    # There is much more that should be in here.
     !request_valid?(request)
   end
 
   def request_valid?(request)
+    # For now, we only care that the correct header is set to see if we're
+    # actually dealing with a notification.
+    # There is much more that should be in here.
+
     request.has_header?('x-amz-sns-message-type') \
     && request.get_header('x-amz-sns-message-type') == 'Notification'
   end

--- a/spec/acceptance/email_notification_spec.rb
+++ b/spec/acceptance/email_notification_spec.rb
@@ -24,11 +24,17 @@ RSpec.describe App do
       }
     end
 
+    let (:sns_headers) do
+      {
+        'x-amz-sns-message-type' => 'Notification'
+      }
+    end
+
     def post_notification
       post '/user-signup/email-notification', {
         Type: 'Notification',
         Message: ses_notification.to_json
-      }.to_json
+      }.to_json, sns_headers
     end
 
     describe 'when the Notification is a signup' do

--- a/spec/acceptance/email_notification_spec.rb
+++ b/spec/acceptance/email_notification_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe App do
       }
     end
 
-    let (:sns_headers) do
+    let(:sns_headers) do
       {
         'x-amz-sns-message-type' => 'Notification'
       }

--- a/spec/unit/lib/wifi_user/use_cases/sns_notification_handler_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/sns_notification_handler_spec.rb
@@ -7,6 +7,7 @@ describe WifiUser::UseCase::SnsNotificationHandler do
   let(:sponsor_signup_handler) { double(execute: nil) }
   let(:logger) { double(debug: nil) }
   let(:notification_type) { 'Notification' }
+  let(:sns_type_header_name) { 'x-amz-sns-message-type' }
 
   subject do
     described_class.new(
@@ -28,6 +29,9 @@ describe WifiUser::UseCase::SnsNotificationHandler do
     )
 
     allow_any_instance_of(Common::Gateway::S3ObjectFetcher).to receive(:fetch) # This will go away once injected
+
+    allow(request).to receive(:get_header).with(sns_type_header_name).and_return(notification_type)
+    allow(request).to receive(:has_header?).with(sns_type_header_name).and_return(true)
   end
 
   it 'parses the request' do


### PR DESCRIPTION
This is required as we don't use handle subscription confirmations yet