### PR TITLE
report SMS sponsee failures to the sponsor

### DIFF
--- a/config/production.yml
+++ b/config/production.yml
@@ -15,6 +15,6 @@ notify_email_template_ids:
   sponsor_confirmation:
     plural: 58e8ef4a-ca6b-40cd-81df-ec9c781fed56
     singular: 30ab6bc5-20bf-45af-b78d-34cacc0027cd
-    failed: efc83658-dcb5-4401-af42-e26b1945c1a9
+    failed: 52c19b68-4d8b-497a-b6ae-ee27d49439c3
 
 do_not_reply_email_id: 0d22d71f-afa3-4c72-8cd4-7716678dbd43

--- a/config/staging.yml
+++ b/config/staging.yml
@@ -15,6 +15,6 @@ notify_email_template_ids:
   sponsor_confirmation:
     plural: 856a5726-1099-4236-b67c-23b654e9edbf
     singular: 079cb5ff-19b7-4a90-b2e8-dad342ca2bf9
-    failed: efabdaea-36cf-4642-b656-2f9a8393ecc2
+    failed: 3b1e71a6-a9be-4ba9-8598-44f4c6de340c
 
 do_not_reply_email_id: 45d6b6c4-6a36-47df-b34d-256b8c0d1511

--- a/lib/wifi_user/use_case/sponsor_users.rb
+++ b/lib/wifi_user/use_case/sponsor_users.rb
@@ -72,7 +72,7 @@ private
   end
 
   def send_confirmation_email(sponsor, sponsees, failed_sponsees: [])
-    return send_sponsor_failed(sponsor, failed_sponsees: failed_sponsees) if sponsees.empty? || !failed_sponsees.empty?
+    return send_failed_sponsoring_email(sponsor, failed_sponsees: failed_sponsees) if sponsees.empty? || !failed_sponsees.empty?
     return send_confirmation_singular(sponsor, sponsees) if sponsees.length == 1
 
     send_confirmation_plural(sponsor, sponsees)
@@ -101,7 +101,7 @@ private
     )
   end
 
-  def send_sponsor_failed(sponsor_address, failed_sponsees: [])
+  def send_failed_sponsoring_email(sponsor_address, failed_sponsees: [])
     notify_client.send_email(
       email_address: sponsor_address,
       template_id: sponsor_confirmation_template['failed'],

--- a/lib/wifi_user/use_case/sponsor_users.rb
+++ b/lib/wifi_user/use_case/sponsor_users.rb
@@ -12,8 +12,8 @@ class WifiUser::UseCase::SponsorUsers
 
     if whitelist_checker.execute(sponsor_address)[:success]
       sponsees = sanitise_sponsees(unsanitised_sponsees)
-      invite_sponsees(sponsor, sponsor_address, sponsees)
-      send_confirmation_email(sponsor_address, sponsees)
+      failed_sponsees = invite_sponsees(sponsor, sponsor_address, sponsees)
+      send_confirmation_email(sponsor_address, sponsees, failed_sponsees: failed_sponsees)
     else
       logger.info("Unsuccessful sponsor signup attempt: #{sponsor_address}")
     end
@@ -28,7 +28,7 @@ private
   end
 
   def invite_sponsees(sponsor, sponsor_address, sponsees)
-    sponsees.each do |sponsee|
+    failed_sponsees = sponsees.reject do |sponsee|
       if email?(sponsee)
         sponsee_address = Mail::Address.new(sponsee).address
         sponsor_email(sponsor, sponsor_address, sponsee_address)
@@ -36,6 +36,7 @@ private
         sponsor_phone_number(sponsor_address, sponsee)
       end
     end
+    failed_sponsees
   end
 
   def notify_client
@@ -51,7 +52,7 @@ private
         login: login_details[:username],
         pass: login_details[:password]
       }
-    )
+    ).success
   end
 
   def sponsor_email(sponsor, sponsor_address, sponsee_address)
@@ -62,14 +63,16 @@ private
       personalisation: login_details.merge(sponsor: sponsor),
       email_reply_to_id: do_not_reply_email_address_id
     )
+    # FIXME: we currently don't support checking if the email was invalid, so always say it is
+    true
   end
 
   def config
     YAML.load_file("config/#{ENV['RACK_ENV']}.yml")
   end
 
-  def send_confirmation_email(sponsor, sponsees)
-    return send_sponsor_failed(sponsor) if sponsees.empty?
+  def send_confirmation_email(sponsor, sponsees, failed_sponsees: [])
+    return send_sponsor_failed(sponsor, failed_sponsees: failed_sponsees) if sponsees.empty? || !failed_sponsees.empty?
     return send_confirmation_singular(sponsor, sponsees) if sponsees.length == 1
 
     send_confirmation_plural(sponsor, sponsees)
@@ -98,11 +101,13 @@ private
     )
   end
 
-  def send_sponsor_failed(sponsor_address)
+  def send_sponsor_failed(sponsor_address, failed_sponsees: [])
     notify_client.send_email(
       email_address: sponsor_address,
       template_id: sponsor_confirmation_template['failed'],
-      personalisation: {},
+      personalisation: {
+        failedSponsees: format_failed_sponsees(failed_sponsees)
+      },
       email_reply_to_id: do_not_reply_email_address_id
     )
   end
@@ -121,5 +126,9 @@ private
 
   def do_not_reply_email_address_id
     YAML.load_file("config/#{ENV['RACK_ENV']}.yml").fetch('do_not_reply_email_id')
+  end
+
+  def format_failed_sponsees(failed_sponsees)
+    failed_sponsees.map { |sponsee| "* #{sponsee}" }.join("\n")
   end
 end

--- a/lib/wifi_user/use_case/sponsor_users.rb
+++ b/lib/wifi_user/use_case/sponsor_users.rb
@@ -66,7 +66,6 @@ private
       personalisation: login_details.merge(sponsor: sponsor),
       email_reply_to_id: do_not_reply_email_address_id
     )
-    # FIXME: we currently don't support checking if the email was invalid, so always say it is
     true
   end
 

--- a/lib/wifi_user/use_case/sponsor_users.rb
+++ b/lib/wifi_user/use_case/sponsor_users.rb
@@ -12,7 +12,7 @@ class WifiUser::UseCase::SponsorUsers
 
     if whitelist_checker.execute(sponsor_address)[:success]
       sponsees = sanitise_sponsees(unsanitised_sponsees)
-      failed_sponsees = invite_sponsees(sponsor, sponsor_address, sponsees)
+      failed_sponsees = invite_sponsees(sponsor, sponsor_address, sponsees)[:failed]
       send_confirmation_email(sponsor_address, sponsees, failed_sponsees: failed_sponsees)
     else
       logger.info("Unsuccessful sponsor signup attempt: #{sponsor_address}")
@@ -36,7 +36,10 @@ private
         sponsor_phone_number(sponsor_address, sponsee)
       end
     end
-    failed_sponsees
+    {
+      success: (sponsees.to_set - failed_sponsees.to_set).to_a,
+      failed: failed_sponsees
+    }
   end
 
   def notify_client

--- a/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
@@ -148,7 +148,6 @@ describe WifiUser::UseCase::SponsorUsers do
         email_address: 'cassandra@gov.uk',
         template_id: '52c19b68-4d8b-497a-b6ae-ee27d49439c3',
         personalisation: {
-          # TODO: this should pick up failed sponsees in the contact sanitisor
           failedSponsees: ''
         },
         email_reply_to_id: do_not_reply_id

--- a/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
@@ -168,7 +168,7 @@ describe WifiUser::UseCase::SponsorUsers do
     end
   end
 
-  context 'On Failing to send an SMS' do
+  context 'on failing to send an SMS' do
     let(:sponsor) { 'Cassandra <cassandra@gov.uk>' }
     let(:success_sponsees) { [] }
     let(:failed_sponsees) { %w(+447770000666) }

--- a/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
@@ -143,7 +143,7 @@ describe WifiUser::UseCase::SponsorUsers do
       expect(user_model).not_to have_received(:generate)
     end
 
-    it 'Sends a sponsorship failed email to the sponsor' do
+    it 'sends a sponsorship failed email to the sponsor' do
       body = {
         email_address: 'cassandra@gov.uk',
         template_id: '52c19b68-4d8b-497a-b6ae-ee27d49439c3',

--- a/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
@@ -176,14 +176,21 @@ describe WifiUser::UseCase::SponsorUsers do
     let(:formatted_failed_sponsees) { "* +447770000666" }
 
     let(:send_sms_gateway) do
-      dbl = double
+      set_send_sms_gateway_execution_branches(
+        double,
+        successful_numbers: success_sponsees,
+        unsucessful_numbers: failed_sponsees
+      )
+    end
+
+    def set_send_sms_gateway_execution_branches(dbl, successful_numbers:, unsucessful_numbers:)
       allow(dbl).to receive(:execute).and_return(double(success: true))
-      success_sponsees.each do |sponsee|
+      successful_numbers.each do |sponsee|
         allow(dbl).to receive(:execute)
           .with(hash_including(phone_number: sponsee))
           .and_return(double(success: true))
       end
-      failed_sponsees.each do |sponsee|
+      unsucessful_numbers.each do |sponsee|
         allow(dbl).to receive(:execute)
           .with(hash_including(phone_number: sponsee))
           .and_return(double(success: false))

--- a/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
@@ -146,8 +146,11 @@ describe WifiUser::UseCase::SponsorUsers do
     it 'Sends a sponsorship failed email to the sponsor' do
       body = {
         email_address: 'cassandra@gov.uk',
-        template_id: 'efc83658-dcb5-4401-af42-e26b1945c1a9',
-        personalisation: {},
+        template_id: '52c19b68-4d8b-497a-b6ae-ee27d49439c3',
+        personalisation: {
+          # TODO: this should pick up failed sponsees in the contact sanitisor
+          failedSponsees: ''
+        },
         email_reply_to_id: do_not_reply_id
       }
       expect(a_request(:post, notify_email_url).with(notify_request(body))).to have_been_made.once
@@ -162,6 +165,76 @@ describe WifiUser::UseCase::SponsorUsers do
 
     it 'Does not call user_model#generate' do
       expect(user_model).not_to have_received(:generate)
+    end
+  end
+
+  context 'On Failing to send an SMS' do
+    let(:sponsor) { 'Cassandra <cassandra@gov.uk>' }
+    let(:success_sponsees) { [] }
+    let(:failed_sponsees) { %w(+447770000666) }
+    let(:sponsees) { success_sponsees + failed_sponsees }
+    let(:do_not_reply_id) { production_do_not_reply_id }
+    let(:formatted_failed_sponsees) { "* +447770000666" }
+
+    let(:send_sms_gateway) do
+      dbl = double
+      allow(dbl).to receive(:execute).and_return(double(success: true))
+      success_sponsees.each do |sponsee|
+        allow(dbl).to receive(:execute)
+          .with(hash_including(phone_number: sponsee))
+          .and_return(double(success: true))
+      end
+      failed_sponsees.each do |sponsee|
+        allow(dbl).to receive(:execute)
+          .with(hash_including(phone_number: sponsee))
+          .and_return(double(success: false))
+      end
+      dbl
+    end
+
+    let(:failing_body) do
+      {
+        email_address: 'cassandra@gov.uk',
+        template_id: '52c19b68-4d8b-497a-b6ae-ee27d49439c3',
+        email_reply_to_id: do_not_reply_id,
+        personalisation: {
+          failedSponsees: formatted_failed_sponsees
+        }
+      }
+    end
+
+    it 'sends a sponsorship failed email to the sponsor' do
+      expect(a_request(:post, notify_email_url).with(notify_request(failing_body))).to have_been_made.once
+    end
+
+    context 'With one success and one fail' do
+      let(:success_sponsees) { %w(+447770000111) }
+      let(:failed_sponsees) { %w(+447770000222) }
+      let(:formatted_failed_sponsees) { "* +447770000222" }
+
+      it 'sends a sponsorship failed email to the sponsor' do
+        expect(a_request(:post, notify_email_url).with(notify_request(failing_body))).to have_been_made.once
+      end
+    end
+
+    context 'With one success and two fail' do
+      let(:success_sponsees) { %w(+447770000111) }
+      let(:failed_sponsees) { %w(+447770000222 +447770000333) }
+      let(:formatted_failed_sponsees) { "* +447770000222\n* +447770000333" }
+
+      it 'sends a sponsorship failed email to the sponsor' do
+        expect(a_request(:post, notify_email_url).with(notify_request(failing_body))).to have_been_made.once
+      end
+    end
+
+    context 'With two success and one fail' do
+      let(:success_sponsees) { %w(+447770000111 +447770000444) }
+      let(:failed_sponsees) { %w(+447770000222 +447770000333) }
+      let(:formatted_failed_sponsees) { "* +447770000222\n* +447770000333" }
+
+      it 'sends a sponsorship failed email to the sponsor' do
+        expect(a_request(:post, notify_email_url).with(notify_request(failing_body))).to have_been_made.once
+      end
     end
   end
 


### PR DESCRIPTION
**WHAT**
report to the sponsor any of the contact details that failed being sent (for phone numbers)

**WHY**
Currently if GovNotify reports a validation error to us, it raises an exception, and the sponsor isn't told anything.
Give the sponsor the opportunity to correct any invalid data in the event of a failure.

**NOTE**
this does not cover reporting validation on email addresses, or dropping sponsees within our contact sanitiser