### PR TITLE
Fix sentry bad request error

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -71,7 +71,8 @@ class App < Sinatra::Base
 
     WifiUser::UseCase::SmsResponse.new(
       user_model: WifiUser::Repository::User.new,
-      template_finder: template_finder
+      template_finder: template_finder,
+      logger: logger
     ).execute(
       contact: params[:source],
       sms_content: params[:message]

--- a/spec/unit/lib/wifi_user/use_cases/contact_sanitiser_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/contact_sanitiser_spec.rb
@@ -27,4 +27,8 @@ describe WifiUser::UseCase::ContactSanitiser do
   it 'does not throw an exception when given crap' do
     expect(subject.execute('asdoihoasdhsioadhj')).to eq(nil)
   end
+
+  it 'does not throw an exception when given a named number' do
+    expect(subject.execute('ABCDELIVERY')).to eq(nil)
+  end
 end

--- a/spec/unit/lib/wifi_user/use_cases/sms_response_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/sms_response_spec.rb
@@ -3,7 +3,7 @@ describe WifiUser::UseCase::SmsResponse do
   let(:template_finder) { double(execute: notify_template_id) }
   subject { described_class.new(user_model: user_model, template_finder: template_finder) }
 
-  context 'With invalid credentials' do
+  context 'With named number' do
     let(:phone_number) { 'HIDDENNUMBER' }
     let(:notify_template_id) { '00000000-7777-8888-9999-000000000000' }
     let(:notify_sms_url) { stub_request(:post, 'https://api.notifications.service.gov.uk/v2/notifications/sms') }
@@ -19,7 +19,7 @@ describe WifiUser::UseCase::SmsResponse do
     end
   end
 
-  context 'with valid credentials'do
+  context 'With valid phone number' do
     before do
       expect(user_model).to receive(:generate).with(contact: phone_number).and_return(username: username, password: password)
     end

--- a/spec/unit/lib/wifi_user/use_cases/sms_response_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/sms_response_spec.rb
@@ -51,6 +51,15 @@ describe WifiUser::UseCase::SmsResponse do
     end
   end
 
+  context 'With no credentials' do
+    let(:phone_number) { '' }
+
+    it 'does not send details to Notify' do
+      subject.execute(contact: phone_number, sms_content: '')
+      expect(notify_sms_stub).to_not have_been_requested
+    end
+  end
+
   context 'For one set of credentials' do
     let(:username) { 'AnExampleUsername' }
     let(:password) { 'AnExamplePassword' }

--- a/spec/unit/lib/wifi_user/use_cases/sms_response_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/sms_response_spec.rb
@@ -3,83 +3,92 @@ describe WifiUser::UseCase::SmsResponse do
   let(:template_finder) { double(execute: notify_template_id) }
   subject { described_class.new(user_model: user_model, template_finder: template_finder) }
 
-  before do
-    expect(user_model).to receive(:generate).with(contact: phone_number).and_return(username: username, password: password)
+  context 'With invalid credentials' do
+    let(:phone_number) { 'HIDDENNUMBER' }
+    let(:notify_template_id) { '00000000-7777-8888-9999-000000000000' }
+    let(:notify_sms_url) { stub_request(:post, 'https://api.notifications.service.gov.uk/v2/notifications/sms') }
+
+    it 'does not create a user' do
+      expect(user_model).to_not receive(:generate)
+      subject.execute(contact: phone_number, sms_content: '')
+    end
+
+    it 'does not send a message to this number' do
+      subject.execute(contact: phone_number, sms_content: '')
+      expect(notify_sms_url).not_to have_been_requested
+    end
   end
 
-  let(:username) { 'hello' }
-  let(:password) { 'password' }
-  let(:phone_number) { '+447700900003' }
-  let(:notify_sms_url) { 'https://api.notifications.service.gov.uk/v2/notifications/sms' }
-  let(:notify_template_id) { '00000000-7777-8888-9999-000000000000' }
-  let(:notify_sms_request) do
-    {
-      phone_number: phone_number,
-      template_id: notify_template_id,
-      personalisation: {
-        login: username,
-        pass: password,
+  context 'with valid credentials'do
+    before do
+      expect(user_model).to receive(:generate).with(contact: phone_number).and_return(username: username, password: password)
+    end
+
+    let(:username) { 'hello' }
+    let(:password) { 'password' }
+    let(:phone_number) { '+447700900003' }
+    let(:notify_sms_url) { 'https://api.notifications.service.gov.uk/v2/notifications/sms' }
+    let(:notify_template_id) { '00000000-7777-8888-9999-000000000000' }
+    let(:notify_sms_request) do
+      {
+        phone_number: phone_number,
+        template_id: notify_template_id,
+        personalisation: {
+          login: username,
+          pass: password,
+        }
       }
-    }
-  end
-  let!(:notify_sms_stub) do
-    stub_request(:post, notify_sms_url).with(body: notify_sms_request)\
-      .to_return(status: 200, body: {}.to_json)
-  end
-
-  it 'Creates a user with the phone number with a +44 already' do
-    subject.execute(contact: '+447700900003', sms_content: '')
-  end
-
-  it 'Creates a user prepended by +44' do
-    subject.execute(contact: '07700900003', sms_content: '')
-  end
-
-  it 'Creates a user prepended by +' do
-    subject.execute(contact: '447700900003', sms_content: '')
-  end
-
-  context 'Calls the template finder with the message content' do
-    it 'with a message of Go' do
-      subject.execute(contact: '447700900003', sms_content: 'Go')
-      expect(template_finder).to have_received(:execute).with(message_content: 'Go')
+    end
+    let!(:notify_sms_stub) do
+      stub_request(:post, notify_sms_url).with(body: notify_sms_request)\
+        .to_return(status: 200, body: {}.to_json)
     end
 
-    it 'with a message of Help' do
-      subject.execute(contact: '447700900003', sms_content: 'Help')
-      expect(template_finder).to have_received(:execute).with(message_content: 'Help')
+    it 'Creates a user with the phone number with a +44 already' do
+      subject.execute(contact: '+447700900003', sms_content: '')
     end
-  end
 
-  context 'With no credentials' do
-    let(:phone_number) { '' }
-
-    it 'does not send details to Notify' do
-      subject.execute(contact: phone_number, sms_content: '')
-      expect(notify_sms_stub).to_not have_been_requested
+    it 'Creates a user prepended by +44' do
+      subject.execute(contact: '07700900003', sms_content: '')
     end
-  end
 
-  context 'For one set of credentials' do
-    let(:username) { 'AnExampleUsername' }
-    let(:password) { 'AnExamplePassword' }
-    let(:phone_number) { '+447700900005' }
-
-    it 'Sends details to Notify' do
-      subject.execute(contact: phone_number, sms_content: '')
-      expect(notify_sms_stub).to have_been_requested.times(1)
+    it 'Creates a user prepended by +' do
+      subject.execute(contact: '447700900003', sms_content: '')
     end
-  end
 
-  context 'With a separate set of credentials' do
-    let(:username) { 'AnotherUsername' }
-    let(:password) { 'AnotherPassword' }
-    let(:phone_number) { '+447700900006' }
-    let(:notify_template_id) { '00000000-3333-3333-3333-000000000000' }
+    context 'Calls the template finder with the message content' do
+      it 'with a message of Go' do
+        subject.execute(contact: '447700900003', sms_content: 'Go')
+        expect(template_finder).to have_received(:execute).with(message_content: 'Go')
+      end
 
-    it 'Sends details to Notify' do
-      subject.execute(contact: phone_number, sms_content: '')
-      expect(notify_sms_stub).to have_been_requested.times(1)
+      it 'with a message of Help' do
+        subject.execute(contact: '447700900003', sms_content: 'Help')
+        expect(template_finder).to have_received(:execute).with(message_content: 'Help')
+      end
+    end
+
+    context 'For one set of credentials' do
+      let(:username) { 'AnExampleUsername' }
+      let(:password) { 'AnExamplePassword' }
+      let(:phone_number) { '+447700900005' }
+
+      it 'Sends details to Notify' do
+        subject.execute(contact: phone_number, sms_content: '')
+        expect(notify_sms_stub).to have_been_requested.times(1)
+      end
+    end
+
+    context 'With a separate set of credentials' do
+      let(:username) { 'AnotherUsername' }
+      let(:password) { 'AnotherPassword' }
+      let(:phone_number) { '+447700900006' }
+      let(:notify_template_id) { '00000000-3333-3333-3333-000000000000' }
+
+      it 'Sends details to Notify' do
+        subject.execute(contact: phone_number, sms_content: '')
+        expect(notify_sms_stub).to have_been_requested.times(1)
+      end
     end
   end
 end


### PR DESCRIPTION
**WHY:**
Sentry Error: 
`Notifications::Client::BadRequestError: [{"error"=>"ValidationError", "message"=>"phone_number None is not of type string"}]`

We have discovered this is due to a named number (like what you get from a bank, where it says LLOYDS as the sender, instead of a number). These cannot be replied to.

**IN THIS PR:**
- Recreate the cause of the error with tests.
- Stop the use case from generating a message based on these kinds of credentials.
- Add a logging functionality that logs to Cloudwatch when this has occurred.

**Any suggestions/feedback would be appreciated**