### PR TITLE
add a quick and dirty mechanism for preventing message loops from happening

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -65,7 +65,12 @@ class App < Sinatra::Base
   # rubocop:enable Metrics/BlockLength
 
   post '/user-signup/sms-notification' do
-    logger.info("Processing SMS on /user-signup/sms-notification from #{params[:source]} with message #{params[:message]}")
+    logger.info("Processing SMS on /user-signup/sms-notification from #{params[:source]} to #{params[:destination]} with message #{params[:message]}")
+
+    if params[:source] == params[:destination]
+      logger.warn("SMS loop detected: #{params[:destination]}")
+      return ''
+    end
 
     template_finder = WifiUser::UseCase::SmsTemplateFinder.new(environment: ENV.fetch('RACK_ENV'))
 

--- a/spec/features/sms_spec.rb
+++ b/spec/features/sms_spec.rb
@@ -11,7 +11,7 @@ describe App do
     end
 
     it 'sends an SMS containing login details back to the user' do
-      post '/user-signup/sms-notification', source: from_phone_number, message: 'Go'
+      post '/user-signup/sms-notification', source: from_phone_number, message: 'Go', destination: ''
 
       expected_request = {
         body: {


### PR DESCRIPTION
We recently had an incident where we were stuck in a loop due a number texting itself.