### PR TITLE
make the SMS loop block aware of international numbers

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -85,9 +85,9 @@ class App < Sinatra::Base
     )
     ''
   end
-  
-  def numbers_are_equal?(number_1, number_2)
+
+  def numbers_are_equal?(number1, number2)
     contact_sanitiser = WifiUser::UseCase::ContactSanitiser.new
-    contact_sanitiser.execute(number_1) == contact_sanitiser.execute(number_2)
+    contact_sanitiser.execute(number1) == contact_sanitiser.execute(number2)
   end
 end

--- a/app.rb
+++ b/app.rb
@@ -67,7 +67,8 @@ class App < Sinatra::Base
   post '/user-signup/sms-notification' do
     logger.info("Processing SMS on /user-signup/sms-notification from #{params[:source]} to #{params[:destination]} with message #{params[:message]}")
 
-    if params[:source] == params[:destination]
+
+    if numbers_are_equal?(params[:source], params[:destination])
       logger.warn("SMS loop detected: #{params[:destination]}")
       return ''
     end
@@ -83,5 +84,10 @@ class App < Sinatra::Base
       sms_content: params[:message]
     )
     ''
+  end
+  
+  def numbers_are_equal?(number_1, number_2)
+    contact_sanitiser = WifiUser::UseCase::ContactSanitiser.new
+    contact_sanitiser.execute(number_1) == contact_sanitiser.execute(number_2)
   end
 end

--- a/spec/acceptance/sms_notification_spec.rb
+++ b/spec/acceptance/sms_notification_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe App do
     let(:from_phone_number) { '07700900000' }
 
     def post_sms_notification
-      post '/user-signup/sms-notification', source: from_phone_number, message: 'Go'
+      post '/user-signup/sms-notification', source: from_phone_number, message: 'Go', destination: ''
     end
 
     it 'returns no sensitive information to sms provider' do

--- a/spec/features/app_spec.rb
+++ b/spec/features/app_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe App do
     end
 
     it 'returns 200' do
-      post '/user-signup/sms-notification', source: '000000000', message: 'Go'
+      post '/user-signup/sms-notification', source: '000000000', message: 'Go', destination: ''
       expect(last_response.body).to eq('')
       expect(last_response).to be_successful
     end

--- a/spec/features/sms_spec.rb
+++ b/spec/features/sms_spec.rb
@@ -32,11 +32,6 @@ describe App do
     end
 
     context 'with a a phone texting itself' do
-      let(:from_phone_number) { '07900000001' }
-      let(:to_phone_number) { '07900000001' }
-
-      
-
       shared_examples "rejecting an SMS" do
         let(:sms_response_stub) { class_double(WifiUser::UseCase::SmsResponse).as_stubbed_const }
         let(:subject) { post '/user-signup/sms-notification', source: from_phone_number, message: 'Go', destination: to_phone_number }
@@ -54,7 +49,7 @@ describe App do
       end
 
       context 'with both the same number' do
-        NUMBERS = %w(07900000001 447900000001 +447900000001)
+        NUMBERS = %w(07900000001 447900000001 +447900000001).freeze
         NUMBERS.each do |from_number|
           NUMBERS.each do |to_number|
             context "with #{from_number} to #{to_number}" do

--- a/spec/features/sms_spec.rb
+++ b/spec/features/sms_spec.rb
@@ -31,6 +31,43 @@ describe App do
       expect(a_request(:post, notify_sms_url).with(expected_request)).to have_been_made.once
     end
 
+    context 'with a a phone texting itself' do
+      let(:from_phone_number) { '07900000001' }
+      let(:to_phone_number) { '07900000001' }
+
+      
+
+      shared_examples "rejecting an SMS" do
+        let(:sms_response_stub) { class_double(WifiUser::UseCase::SmsResponse).as_stubbed_const }
+        let(:subject) { post '/user-signup/sms-notification', source: from_phone_number, message: 'Go', destination: to_phone_number }
+
+        it 'gives an empty ok' do
+          subject
+          expect(last_response.ok?).to be true
+          expect(last_response.body).to eq('')
+        end
+
+        it 'does not send an SMS' do
+          expect(sms_response_stub).not_to receive(:new)
+          subject
+        end
+      end
+
+      context 'with both the same number' do
+        NUMBERS = %w(07900000001 447900000001 +447900000001)
+        NUMBERS.each do |from_number|
+          NUMBERS.each do |to_number|
+            context "with #{from_number} to #{to_number}" do
+              let(:from_phone_number) { from_number }
+              let(:to_phone_number) { to_number }
+
+              it_behaves_like "rejecting an SMS"
+            end
+          end
+        end
+      end
+    end
+
     def created_user
       WifiUser::Repository::User.find(contact: internationalised_phone_number)
     end


### PR DESCRIPTION
Firetext gives us different formats, so we need to normalise first.

This also introduces tests to verify all reasonable combinations are checked in the SMS block