### PR TITLE
treat the auth token as a bearer token

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -127,6 +127,6 @@ class App < Sinatra::Base
   end
 
   def is_govnotify_token_valid?
-    env.fetch('HTTP_AUTHORIZATION') == options.govnotify_token
+    env.fetch('HTTP_AUTHORIZATION') == "Bearer #{options.govnotify_token}"
   end
 end

--- a/spec/features/notify/sms_spec.rb
+++ b/spec/features/notify/sms_spec.rb
@@ -15,7 +15,7 @@ describe App do
     it 'sends an SMS containing login details back to the user' do
       post '/user-signup/sms-notification/notify',
         { source_number: from_phone_number, message: 'Go', destination_number: '' },
-        'HTTP_AUTHORIZATION' => notify_token
+        'HTTP_AUTHORIZATION' => "Bearer #{notify_token}"
 
       expected_request = {
         body: {
@@ -41,7 +41,7 @@ describe App do
         let(:subject) do
           post '/user-signup/sms-notification/notify',
             { source_number: from_phone_number, message: 'Go', destination_number: to_phone_number },
-            'HTTP_AUTHORIZATION' => notify_token
+            'HTTP_AUTHORIZATION' => "Bearer #{notify_token}"
         end
 
         it 'gives an empty ok' do
@@ -77,7 +77,7 @@ describe App do
       before do
         post '/user-signup/sms-notification/notify',
           { source_number: from_phone_number, message: 'Go', destination_number: '' },
-          'HTTP_AUTHORIZATION' => notify_token
+          'HTTP_AUTHORIZATION' => "Bearer #{notify_token}"
       end
 
       it 'receives an unauthorised response' do


### PR DESCRIPTION
that is to say, prepend the auth string with 'Bearer'