### PR TITLE
Append whitespace to username for SMS notifications

### DIFF
--- a/lib/wifi_user/use_case/sms_response.rb
+++ b/lib/wifi_user/use_case/sms_response.rb
@@ -10,7 +10,7 @@ class WifiUser::UseCase::SmsResponse
     return logger.warn("Unexpected contact detail found #{contact}") if phone_number.nil?
 
     login_details = user_model.generate(contact: phone_number)
-    notify_params = { login: login_details[:username], pass: login_details[:password] }
+    notify_params = { login: "#{login_details[:username]} ", pass: login_details[:password] }
     send_signup_instructions(phone_number, notify_params, sms_content)
   end
 

--- a/spec/features/sms_spec.rb
+++ b/spec/features/sms_spec.rb
@@ -32,7 +32,7 @@ describe App do
           "phone_number": internationalised_phone_number,
           "template_id": notify_template_id,
           "personalisation": {
-            "login": created_user.username,
+            "login": "#{created_user.username} ",
             "pass": created_user.password
           }
         },

--- a/spec/unit/lib/wifi_user/use_cases/sms_response_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/sms_response_spec.rb
@@ -34,7 +34,7 @@ describe WifiUser::UseCase::SmsResponse do
         phone_number: phone_number,
         template_id: notify_template_id,
         personalisation: {
-          login: username,
+          login: "#{username} ",
           pass: password,
         }
       }


### PR DESCRIPTION
https://trello.com/c/opNiPkUn/22-no-space-between-end-of-username-and-password-on-end-user-signup-sms

Some mobile devices do not present the login and password credentials on separate lines n the SMS response.
This leads to the username being concatenated with the SMS template text preceding the password. This often confuses users as they attempt to transfer these values into their Wifi settings.

This commit appends a single space char to the end of the login value for clearer presentation in the SMS template. Ideally we'd amend the template to ensure the correct layout but these managed in Notify and would be harder to test.