### PR TITLE
Restrict username generation character list to reduce ambiguity

### DIFF
--- a/lib/wifi_user/repository/user.rb
+++ b/lib/wifi_user/repository/user.rb
@@ -13,7 +13,7 @@ class WifiUser::Repository::User < Sequel::Model(:userdetails)
 
 private
 
-  ALPHABET_WITHOUT_VOWELS = %w(b c d f g h j k l m n p q r s t v w x y z).freeze
+  CHARACTER_LIST = %w(b c d f g h j k m n p q r s t v w x y z).freeze
 
   def random_username
     username = generate_username
@@ -26,7 +26,7 @@ private
   end
 
   def generate_username
-    (0...6).map { ALPHABET_WITHOUT_VOWELS[rand(ALPHABET_WITHOUT_VOWELS.count)] }.join
+    (0...6).map { CHARACTER_LIST[rand(CHARACTER_LIST.count)] }.join
   end
 
   def password_from_word_list

--- a/spec/unit/lib/wifi_user/repository/user_spec.rb
+++ b/spec/unit/lib/wifi_user/repository/user_spec.rb
@@ -4,7 +4,7 @@ describe WifiUser::Repository::User do
   end
 
   describe '#generate' do
-    ALPHABET_WITHOUT_VOWELS = %w(b c d f g h j k l m n p q r s t v w x y z).freeze
+    CHARACTER_LIST = %w(b c d f g h j k m n p q r s t v w x y z).freeze
 
     let(:word_list) { %w[These Are Words] }
 
@@ -19,7 +19,7 @@ describe WifiUser::Repository::User do
 
     let(:random_username) do
       srand(2)
-      (0...6).map { ALPHABET_WITHOUT_VOWELS[rand(ALPHABET_WITHOUT_VOWELS.count)] }.join
+      (0...6).map { CHARACTER_LIST[rand(CHARACTER_LIST.count)] }.join
     end
 
     context 'new user' do


### PR DESCRIPTION
https://trello.com/c/QxaXNAPq/23-ensure-the-first-letter-of-a-username-is-not-an-ambiguous-letter-eg-lowercase-l-or-uppercase-i

Usernames beginning with a lowercase 'l' can cause confusion entering credentials.
I can't see any other characters in the relevant list which would cause similar ambiguity.