### PR TITLE
Strip spaces from phone numbers

### DIFF
--- a/lib/wifi_user/use_case/contact_sanitiser.rb
+++ b/lib/wifi_user/use_case/contact_sanitiser.rb
@@ -4,7 +4,7 @@ class WifiUser::UseCase::ContactSanitiser
   def execute(contact)
     first_match(
       email_match(contact) ||
-      internationalize(phone_match(contact)) ||
+      internationalize(phone_match(contact.delete(' '))) ||
       NO_MATCH
     )
   end

--- a/spec/unit/lib/wifi_user/use_cases/contact_sanitiser_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/contact_sanitiser_spec.rb
@@ -19,6 +19,11 @@ describe WifiUser::UseCase::ContactSanitiser do
     expect(subject.execute(phone_number)).to eq('+447700900004')
   end
 
+  it 'strips spaces from a phone number' do
+    phone_number = '07700 900 004'
+    expect(subject.execute(phone_number)).to eq('+447700900004')
+  end
+
   it 'passes through an internationalised phone number' do
     phone_number = '+447700900004'
     expect(subject.execute(phone_number)).to eq('+447700900004')

--- a/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/sponsor_users_spec.rb
@@ -56,7 +56,7 @@ describe WifiUser::UseCase::SponsorUsers do
 
   context 'Sponsoring a single phone number' do
     let(:sponsor) { 'Craig <craig@gov.uk>' }
-    let(:sponsees) { ['+447700900003'] }
+    let(:sponsees) { ['+44 7700 900003'] }
 
     it 'Calls user_model#generate with the sponsees phone number' do
       expect(user_model).to have_received(:generate) \


### PR DESCRIPTION
https://trello.com/c/i8AXvykM/40-when-sponsoring-a-phone-number-that-contains-a-space-it-doesnt-sponsor-that-number

Remove spaces from sponsee phone numbers before saving and notifying them via SMS.