### PR TITLE
Filter sponsor email address when extracting sponsees

### DIFF
--- a/lib/wifi_user/use_case/email_sponsees_extractor.rb
+++ b/lib/wifi_user/use_case/email_sponsees_extractor.rb
@@ -1,16 +1,16 @@
 require 'nokogiri'
 
 class WifiUser::UseCase::EmailSponseesExtractor
-  def initialize(email_fetcher:, sponsor_address:)
+  def initialize(email_fetcher:, exclude_addresses:)
     @email_fetcher = email_fetcher
-    @sponsor_address = sponsor_address
+    @exclude_addresses = exclude_addresses
   end
 
   def execute
     mail = Mail.read_from_string(email_fetcher.fetch)
 
     contacts_from_mail(mail).map(&:strip).reject(&:empty?)
-                            .reject { |contact| @sponsor_address == contact }
+      .reject { |contact| @exclude_addresses.include?(contact) }
   end
 
 private

--- a/lib/wifi_user/use_case/email_sponsees_extractor.rb
+++ b/lib/wifi_user/use_case/email_sponsees_extractor.rb
@@ -1,14 +1,16 @@
 require 'nokogiri'
 
 class WifiUser::UseCase::EmailSponseesExtractor
-  def initialize(email_fetcher:)
+  def initialize(email_fetcher:, sponsor_address:)
     @email_fetcher = email_fetcher
+    @sponsor_address = sponsor_address
   end
 
   def execute
     mail = Mail.read_from_string(email_fetcher.fetch)
 
     contacts_from_mail(mail).map(&:strip).reject(&:empty?)
+                            .reject { |contact| @sponsor_address == contact }
   end
 
 private

--- a/lib/wifi_user/use_case/sns_notification_handler.rb
+++ b/lib/wifi_user/use_case/sns_notification_handler.rb
@@ -56,7 +56,10 @@ private
       bucket: payload.fetch(:s3_bucket_name),
       key: payload.fetch(:s3_object_key)
     )
-    sponsee_extractor = WifiUser::UseCase::EmailSponseesExtractor.new(email_fetcher: email_fetcher)
+    sponsee_extractor = WifiUser::UseCase::EmailSponseesExtractor.new(
+      email_fetcher: email_fetcher,
+      sponsor_address: from_address
+    )
 
     sponsor_signup_handler.execute(sponsee_extractor.execute, from_address)
   end

--- a/lib/wifi_user/use_case/sns_notification_handler.rb
+++ b/lib/wifi_user/use_case/sns_notification_handler.rb
@@ -58,7 +58,7 @@ private
     )
     sponsee_extractor = WifiUser::UseCase::EmailSponseesExtractor.new(
       email_fetcher: email_fetcher,
-      sponsor_address: from_address
+      exclude_addresses: [from_address]
     )
 
     sponsor_signup_handler.execute(sponsee_extractor.execute, from_address)

--- a/spec/acceptance/email_notification_spec.rb
+++ b/spec/acceptance/email_notification_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe App do
       it 'constructs WifiUser::UseCase::EmailSponseesExtractor with the Common::Gateway::S3ObjectFetcher' do
         post_notification
         expect(WifiUser::UseCase::EmailSponseesExtractor).to have_received(:new)
-          .with(email_fetcher: email_fetcher, sponsor_address: from_address)
+          .with(email_fetcher: email_fetcher, exclude_addresses: [from_address])
       end
 
       it 'calls WifiUser::UseCase::SponsorUsers with the sponsees from WifiUser::UseCase::EmailSponseesExtractor and from address' do

--- a/spec/acceptance/email_notification_spec.rb
+++ b/spec/acceptance/email_notification_spec.rb
@@ -96,7 +96,8 @@ RSpec.describe App do
 
       it 'constructs WifiUser::UseCase::EmailSponseesExtractor with the Common::Gateway::S3ObjectFetcher' do
         post_notification
-        expect(WifiUser::UseCase::EmailSponseesExtractor).to have_received(:new).with(email_fetcher: email_fetcher)
+        expect(WifiUser::UseCase::EmailSponseesExtractor).to have_received(:new)
+          .with(email_fetcher: email_fetcher, sponsor_address: from_address)
       end
 
       it 'calls WifiUser::UseCase::SponsorUsers with the sponsees from WifiUser::UseCase::EmailSponseesExtractor and from address' do

--- a/spec/unit/lib/wifi_user/use_cases/email_sponsees_extractor_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/email_sponsees_extractor_spec.rb
@@ -3,7 +3,7 @@ describe WifiUser::UseCase::EmailSponseesExtractor do
   let(:email_fetcher) { double(fetch: email.to_s) }
   let(:sponsees) { subject.execute }
 
-  subject { described_class.new(email_fetcher: email_fetcher) }
+  subject { described_class.new(email_fetcher: email_fetcher, sponsor_address: 'sponsor@example.com') }
 
   it 'Grabs a single email address' do
     email.body = 'adrian@example.com'
@@ -70,6 +70,11 @@ describe WifiUser::UseCase::EmailSponseesExtractor do
     it 'Base64 encoded HTML message' do
       test_case 'email-sponsor-base64-htmlonly'
       expect(sponsees).to eq(['example.user2@example.co.uk', '07123456789'])
+    end
+
+    it 'Filters the sponsor address from results' do
+      email.body = "adrian@example.com\r\nchris@example.com\r\nsponsor@example.com"
+      expect(sponsees).to eq(['adrian@example.com', 'chris@example.com'])
     end
 
     def test_case(regression_test_name)

--- a/spec/unit/lib/wifi_user/use_cases/email_sponsees_extractor_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/email_sponsees_extractor_spec.rb
@@ -3,7 +3,7 @@ describe WifiUser::UseCase::EmailSponseesExtractor do
   let(:email_fetcher) { double(fetch: email.to_s) }
   let(:sponsees) { subject.execute }
 
-  subject { described_class.new(email_fetcher: email_fetcher, sponsor_address: 'sponsor@example.com') }
+  subject { described_class.new(email_fetcher: email_fetcher, exclude_addresses: %W(sponsor@example.com)) }
 
   it 'Grabs a single email address' do
     email.body = 'adrian@example.com'


### PR DESCRIPTION
https://trello.com/c/1NR2y1XC/41-sponsors-emails-eg-in-signature-should-not-themselves-be-sponsored

Filters sponsors email from the list of extracted sponsee addresses.