### PR TITLE
Ensure full email addresses are acceptable in exclusion list

### DIFF
--- a/lib/wifi_user/use_case/email_sponsees_extractor.rb
+++ b/lib/wifi_user/use_case/email_sponsees_extractor.rb
@@ -3,7 +3,7 @@ require 'nokogiri'
 class WifiUser::UseCase::EmailSponseesExtractor
   def initialize(email_fetcher:, exclude_addresses:)
     @email_fetcher = email_fetcher
-    @exclude_addresses = exclude_addresses
+    @exclude_addresses = exclude_addresses.map { |addr| Mail::Address.new(addr).address }
   end
 
   def execute

--- a/spec/unit/lib/wifi_user/use_cases/email_sponsees_extractor_spec.rb
+++ b/spec/unit/lib/wifi_user/use_cases/email_sponsees_extractor_spec.rb
@@ -3,7 +3,7 @@ describe WifiUser::UseCase::EmailSponseesExtractor do
   let(:email_fetcher) { double(fetch: email.to_s) }
   let(:sponsees) { subject.execute }
 
-  subject { described_class.new(email_fetcher: email_fetcher, exclude_addresses: %W(sponsor@example.com)) }
+  subject { described_class.new(email_fetcher: email_fetcher, exclude_addresses: ['Sponsor <sponsor@example.com>']) }
 
   it 'Grabs a single email address' do
     email.body = 'adrian@example.com'


### PR DESCRIPTION
The addresses in the exclusion list may be fully formed ie. 'First Last <first.last@domain.org>'
these will be parsed so the email address segment is used when filtering out the sponsor.

Fixes an assumption in https://github.com/alphagov/govwifi-user-signup-api/pull/203