### PR TITLE
Fix wordlist seed during build

### DIFF
--- a/ci/tasks/build-deployable.yml
+++ b/ci/tasks/build-deployable.yml
@@ -28,5 +28,6 @@ run:
   args:
     - '-exc'
     - |
+      aws s3 cp s3://govwifi-wordlist/wordlist-short ./tmp/wordlist
       echo "$TAG" > image/tag
       build


### PR DESCRIPTION
Fixes an issue where we were not retrieving the wordlist seed file at build time.

TODO: refactor to use aws-helpers in govwifi-concourse-deploy-pipelines

Co-Authored-By: Steve Laing <steve.laing@digital.cabinet-office.gov.uk>