### PR TITLE
RED-104: Pass wordlist file as an input to container build task

### DIFF
--- a/ci/tasks/build-deployable.yml
+++ b/ci/tasks/build-deployable.yml
@@ -16,6 +16,7 @@ params:
 
 inputs:
   - name: src
+  - name: wordlist-file
 
 outputs:
   - name: image
@@ -28,6 +29,6 @@ run:
   args:
     - '-exc'
     - |
-      aws s3 cp s3://govwifi-wordlist/wordlist-short ./tmp/wordlist
+      cp wordlist-file ./tmp/wordlist
       echo "$TAG" > image/tag
       build


### PR DESCRIPTION
The build container does not have the aws cli installed. Instead, the deploy pipeline has been updated to download the wordlist file resource which may now be accessed within this task via an input.