### PR TITLE
RED-104: Rename filename copied into build container

### DIFF
--- a/ci/tasks/build-deployable.yml
+++ b/ci/tasks/build-deployable.yml
@@ -29,6 +29,6 @@ run:
   args:
     - '-exc'
     - |
-      cp wordlist-file ./tmp/wordlist
+      cp wordlist-short ./tmp/wordlist
       echo "$TAG" > image/tag
       build


### PR DESCRIPTION
The `wordlist-file` input from the s3 resource actually creates several files within the context of the build container. The copied resource has name of the downloaded file, not the name of the input. This can't be changed using input mapping.