### PR TITLE
RED-104: Copy wordlist from mounted path

### DIFF
--- a/ci/tasks/build-deployable.yml
+++ b/ci/tasks/build-deployable.yml
@@ -29,6 +29,6 @@ run:
   args:
     - '-exc'
     - |
-      cp wordlist-short ./tmp/wordlist
+      cp wordlist-file/wordlist-short ./tmp/wordlist
       echo "$TAG" > image/tag
       build


### PR DESCRIPTION
The wordlist-file S3 resource mounts a directory containing various files. The wordlist artefact from the previous step may be copied into the desired path from here.