### PR TITLE
RED-104: Create tmp directory before copying wordlist file

### DIFF
--- a/ci/tasks/build-deployable.yml
+++ b/ci/tasks/build-deployable.yml
@@ -29,6 +29,7 @@ run:
   args:
     - '-exc'
     - |
+      mkdir ./tmp
       cp wordlist-file/wordlist-short ./tmp/wordlist
       echo "$TAG" > image/tag
       build


### PR DESCRIPTION
File copy fails unless directory exists.