### PR TITLE
Ensure wordlist is copied to src/tmp

### DIFF
--- a/ci/tasks/build-deployable.yml
+++ b/ci/tasks/build-deployable.yml
@@ -29,7 +29,6 @@ run:
   args:
     - '-exc'
     - |
-      mkdir ./tmp
-      cp wordlist-file/wordlist-short ./tmp/wordlist
+      cp wordlist-file/wordlist-short ./src/tmp/wordlist
       echo "$TAG" > image/tag
       build


### PR DESCRIPTION
The build deployable step executes a directory up from the app source so ensure we copy the wordlist into `./src/tmp`