### PR TITLE
Add batch deletion of old user accounts to reduce RDS lag

### DIFF
--- a/lib/gdpr/gateway/usedetails.rb
+++ b/lib/gdpr/gateway/usedetails.rb
@@ -8,7 +8,7 @@ class Gdpr::Gateway::Userdetails
 
     total = 0
     loop do
-      deleted_rows = DB[:sessions].with_sql_delete("
+      deleted_rows = DB[:userdetails].with_sql_delete("
         DELETE FROM userdetails WHERE (last_login < DATE_SUB(NOW(), INTERVAL 12 MONTH)
         OR (last_login IS NULL AND created_at < DATE_SUB(NOW(), INTERVAL 12 MONTH)))
         AND username != 'HEALTH'

--- a/lib/gdpr/gateway/usedetails.rb
+++ b/lib/gdpr/gateway/usedetails.rb
@@ -1,9 +1,26 @@
+require 'logger'
+
 class Gdpr::Gateway::Userdetails
+  SESSION_BATCH_SIZE = 500
   def delete_users
-    DB.run('DELETE FROM userdetails
-        WHERE (last_login < DATE_SUB(NOW(), INTERVAL 12 MONTH)
+    logger = Logger.new(STDOUT)
+    logger.info('Starting daily old user deletion')
+
+    total = 0
+    loop do
+      deleted_rows = DB[:sessions].with_sql_delete("
+        DELETE FROM userdetails WHERE (last_login < DATE_SUB(NOW(), INTERVAL 12 MONTH)
         OR (last_login IS NULL AND created_at < DATE_SUB(NOW(), INTERVAL 12 MONTH)))
-        AND username != "HEALTH"')
+        AND username != 'HEALTH'
+        LIMIT #{SESSION_BATCH_SIZE}")
+      total += deleted_rows
+
+      if deleted_rows.zero?
+        break
+      end
+    end
+
+    logger.info("Finished daily old user deletion, #{total} rows affected")
   end
 
   def obfuscate_sponsors


### PR DESCRIPTION
Currently when the deletion of old user accounts occur, a lag
in RDS replication occurs, which in turn fires a cloudwatch
alarm. As it self heals, this alarm is ignored but it does
create unnecessary noise which we have all become numb to.

We believe the cause is because of how large the query is,
and that it creates a single large transaction log which
needs to be first copied across and fully replayed on the
replica, and during this replay the lag is created.

This PR breaks the old user account deletion query into
batches of 500, with the intent to allow each batch to be
replicated and replayed on to the replica whilst other
batches are still being created on the master, thus
dampening the effect of the replication and reducing lag.