### PR TITLE
Enable manual trigger for the Concourse job 'lint & test'

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -101,8 +101,6 @@ jobs:
 
   - name: lint & test
     interruptible: true
-    # force people to use new git commits to rerun PRs
-    disable_manual_trigger: true
     plan:
       - aggregate:
         - do:


### PR DESCRIPTION
This is needed because there seems to be some flakiness in our build,
which means a failed build stop a PR from getting merged and the only
way is to add a phantom commit.