### PR TITLE
Publish monthly and daily completion rate stats

### DIFF
--- a/lib/performance_platform/gateway/completion_rate.rb
+++ b/lib/performance_platform/gateway/completion_rate.rb
@@ -1,11 +1,12 @@
 class PerformancePlatform::Gateway::CompletionRate
-  def initialize(date: Date.today.to_s)
+  def initialize(date: Date.today.to_s, period: "week")
     @date = Date.parse(date)
+    @period = period
   end
 
   def fetch_stats
     {
-      period: "week",
+      period: @period,
       metric_name: "completion-rate",
       sms_registered: sms_registered.count,
       sms_logged_in: sms_logged_in.count,
@@ -25,15 +26,15 @@ private
   end
 
   def sms_registered
-    repository.self_sign.with_sms.week_before(date)
+    repository.self_sign.with_sms.send("#{@period}_before", date)
   end
 
   def email_registered
-    repository.self_sign.with_email.week_before(date)
+    repository.self_sign.with_email.send("#{@period}_before", date)
   end
 
   def sponsor_registered
-    repository.sponsored.week_before(date)
+    repository.sponsored.send("#{@period}_before", date)
   end
 
   def sms_logged_in


### PR DESCRIPTION
This is a first attempt.  We don't know much about how the Performance Platform actually works (and we might end up using some other mechanism to consume the published stats).

I've adapted the existing tasks in publish_statistics, rather than adding new ones, since I feel it'd be confusing to have multiple 'monthly' tasks (ditto for 'daily').  I''m assuming this will work, but who knows.

Not sure whether/how we can go about adding test coverage for this work.


https://trello.com/c/rtF5XZpO/