### PR TITLE
Upload Volumetrics to S3

### DIFF
--- a/lib/metrics/s3_publisher.rb
+++ b/lib/metrics/s3_publisher.rb
@@ -1,0 +1,13 @@
+module Metrics
+  class S3Publisher
+    def self.publish(key, stats)
+      bucket = ENV.fetch("S3_METRICS_BUCKET")
+
+      Services.s3_client.put_object(
+        bucket: bucket,
+        key: key,
+        body: stats.to_json.to_s,
+      )
+    end
+  end
+end

--- a/lib/metrics/volumetrics.rb
+++ b/lib/metrics/volumetrics.rb
@@ -1,0 +1,30 @@
+module Metrics
+  class Volumetrics
+    VALID_PERIODS = %w[week day month].freeze
+
+    def initialize(attrs)
+      raise ArgumentError unless VALID_PERIODS.include? attrs[:period]
+
+      @period = attrs[:period]
+      @date = attrs[:date]
+    end
+
+    def execute
+      S3Publisher.publish key, stats
+    end
+
+    def key
+      "volumetrics/volumetrics-#{@period}-#{@date}"
+    end
+
+  private
+
+    def stats
+      gateway = PerformancePlatform::Gateway::Volumetrics.new(
+        period: @period,
+        date: @date,
+      )
+      gateway.fetch_stats
+    end
+  end
+end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,0 +1,5 @@
+class Services
+  def self.s3_client
+    Aws::S3::Client.new(region: "eu-west-2")
+  end
+end

--- a/spec/factories/user_details.rb
+++ b/spec/factories/user_details.rb
@@ -1,0 +1,40 @@
+FactoryBot.define do
+  factory :user_details, class: WifiUser::Repository::User do
+    to_create(&:save)
+
+    username { SecureRandom.alphanumeric(6).downcase }
+
+    sequence :contact, 1 do |n|
+      "username#{n}.domain.uk"
+    end
+
+    sequence :sponsor, 1 do |n|
+      "sponsor#{n}.domain.uk"
+    end
+
+    password { SecureRandom.alphanumeric(10).downcase }
+    notifications_opt_out { 0 }
+    survey_opt_out { 0 }
+    last_login { Date.today }
+    created_at { Date.today }
+    updated_at { Date.today }
+
+    trait :self_signed do
+      transient do
+        sequence :email_address, 1 do |n|
+          "self_signed#{n}@domain.uk"
+        end
+      end
+      contact { email_address }
+      sponsor { email_address }
+    end
+
+    trait :sms do
+      transient do
+        random_sms_no { "+4477#{SecureRandom.random_number(100_000_000)}" }
+      end
+      contact { random_sms_no }
+      sponsor { random_sms_no }
+    end
+  end
+end

--- a/spec/unit/lib/metrics/s3_fake_client.rb
+++ b/spec/unit/lib/metrics/s3_fake_client.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Metrics
+  def self.fake_s3_client
+    fake_s3 = {}
+    Aws::S3::Client.new(stub_responses: true).tap do |client|
+      client.stub_responses(
+        :put_object, lambda { |context|
+                       bucket = context.params[:bucket]
+                       key = context.params[:key]
+                       body = context.params[:body]
+                       fake_s3[bucket] ||= {}
+                       fake_s3[bucket][key] = body
+                       {}
+                     }
+      )
+      client.stub_responses(
+        :get_object, lambda { |context|
+                       bucket = context.params[:bucket]
+                       key = context.params[:key]
+                       { body: fake_s3.dig(bucket, key) }
+                     }
+      )
+    end
+  end
+end

--- a/spec/unit/lib/metrics/volumetrics_spec.rb
+++ b/spec/unit/lib/metrics/volumetrics_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require_relative "./s3_fake_client"
+
+describe Metrics::Volumetrics do
+  let(:today) { Date.today }
+  let(:twelve_hours_ago) { today - 0.5 }
+  let(:yesterday) { today - 1 }
+  let(:two_days_ago) { today - 2 }
+  let(:last_week) { today - 7 }
+  let(:last_year) { today << 12 }
+  let(:s3_client) { Metrics.fake_s3_client }
+
+  subject do
+    Metrics::Volumetrics.new(period: period,
+                             date: start_date.to_s)
+  end
+
+  before do
+    ENV["S3_METRICS_BUCKET"] = "stub-bucket"
+    DB[:userdetails].truncate
+    allow(Services).to receive(:s3_client).and_return s3_client
+  end
+
+  it "rejects invalid periods" do
+    expect { Metrics::Volumetrics.new(period: "foo", date: Date.today.to_s) }
+      .to raise_error(ArgumentError)
+  end
+
+  describe "#execute" do
+    before do
+      FactoryBot.create(:user_details, created_at: twelve_hours_ago)
+      FactoryBot.create(:user_details, created_at: two_days_ago)
+      FactoryBot.create(:user_details, created_at: last_week)
+      FactoryBot.create(:user_details, created_at: last_year)
+      FactoryBot.create(:user_details, :sms, created_at: twelve_hours_ago)
+      FactoryBot.create(:user_details, :sms, created_at: two_days_ago)
+      FactoryBot.create(:user_details, :sms, created_at: last_week)
+      FactoryBot.create(:user_details, :sms, created_at: last_year)
+      FactoryBot.create(:user_details, :self_signed, created_at: twelve_hours_ago)
+      FactoryBot.create(:user_details, :self_signed, created_at: two_days_ago)
+      FactoryBot.create(:user_details, :self_signed, created_at: last_week)
+      FactoryBot.create(:user_details, :self_signed, created_at: last_year)
+
+      subject.execute
+
+      result = s3_client.get_object(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: subject.key).body.read
+      @parsed_result = JSON.parse(result)
+    end
+
+    describe "The start date is yesterday and the period is a month" do
+      let(:start_date) { yesterday }
+      let(:period) { "month" }
+
+      it "uploads information that 6 users were created between yesterday and a month before" do
+        expect(@parsed_result["period_before"]).to eq(6)
+      end
+
+      it "uploads information that 9 users were created before yesterday" do
+        expect(@parsed_result["cumulative"]).to eq(9)
+      end
+
+      it "uploads information that 2 self signed SMS users were created between yesterday and a month before" do
+        expect(@parsed_result["sms_period_before"]).to eq(2)
+      end
+
+      it "uploads information that 3 self signed SMS users were created before yesterday" do
+        expect(@parsed_result["sms_cumulative"]).to eq(3)
+      end
+
+      it "uploads information that 2 self signed Email users were created between yesterday and a month before" do
+        expect(@parsed_result["email_period_before"]).to eq(2)
+      end
+
+      it "uploads information that 3 self signed Email users were created before yesterday" do
+        expect(@parsed_result["email_cumulative"]).to eq(3)
+      end
+    end
+
+    describe "The start date is today and the period is a day" do
+      let(:start_date) { today }
+      let(:period) { "day" }
+
+      it "uploads information that 3 users were created between today and yesterday" do
+        expect(@parsed_result["period_before"]).to eq(3)
+      end
+
+      it "uploads information that 12 users were created before today" do
+        expect(@parsed_result["cumulative"]).to eq(12)
+      end
+
+      it "uploads information that 1 self signed SMS user was created between today and yesterday" do
+        expect(@parsed_result["sms_period_before"]).to eq(1)
+      end
+
+      it "uploads information that 4 self signed SMS users were created before today" do
+        expect(@parsed_result["sms_cumulative"]).to eq(4)
+      end
+
+      it "uploads information that 1 self signed Email user was created between today and yesterday" do
+        expect(@parsed_result["email_period_before"]).to eq(1)
+      end
+
+      it "uploads information that 4 self signed Email users were created before today" do
+        expect(@parsed_result["email_cumulative"]).to eq(4)
+      end
+    end
+  end
+end

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -36,3 +36,23 @@ PERIODS.each do |adverbial, period|
     ).execute(presenter: completion_rate_presenter)
   end
 end
+
+PERIODS.each do |adverbial, period|
+  name = "publish_#{adverbial}_metrics".to_sym
+
+  task name, [:date] do |_, args|
+    require "./lib/loader"
+
+    args.with_defaults(date: Date.today.to_s)
+
+    logger.info("Creating #{adverbial} metrics for S3 with #{args[:date]}")
+
+    metrics = Metrics::Volumetrics.new(period: period, date: args[:date])
+
+    logger.info("[#{metrics.key}] Fetching and uploading metrics...")
+
+    metrics.execute
+
+    logger.info("[#{metrics.key}] Done.")
+  end
+end


### PR DESCRIPTION
Data points about volumetrics that are normally sent to the PP
are now also sent to an S3 bucket. This because the Performance Platform is soon to be retired.

https://trello.com/c/ezleXA51/409-upload-volumetrics-data-points-to-s3