### PR TITLE
Upload Completion Rate metrics to S3

### DIFF
--- a/lib/metrics/completion_rate.rb
+++ b/lib/metrics/completion_rate.rb
@@ -1,0 +1,30 @@
+module Metrics
+  class CompletionRate
+    VALID_PERIODS = %w[week day month].freeze
+
+    def initialize(attrs)
+      raise ArgumentError unless VALID_PERIODS.include? attrs[:period]
+
+      @period = attrs[:period]
+      @date = attrs[:date]
+    end
+
+    def execute
+      S3Publisher.publish key, stats
+    end
+
+    def key
+      "completion_rate/completion_rate-#{@period}-#{@date}"
+    end
+
+  private
+
+    def stats
+      gateway = PerformancePlatform::Gateway::CompletionRate.new(
+        period: @period,
+        date: @date,
+      )
+      gateway.fetch_stats
+    end
+  end
+end

--- a/spec/factories/user_details.rb
+++ b/spec/factories/user_details.rb
@@ -29,6 +29,10 @@ FactoryBot.define do
       sponsor { email_address }
     end
 
+    trait :not_logged_in do
+      last_login { nil }
+    end
+
     trait :sms do
       transient do
         random_sms_no { "+4477#{SecureRandom.random_number(100_000_000)}" }

--- a/spec/unit/lib/metrics/completion_rate_spec.rb
+++ b/spec/unit/lib/metrics/completion_rate_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative "./s3_fake_client"
+
+describe Metrics::Volumetrics do
+  let(:today) { Date.today }
+  let(:twelve_hours_ago) { today - 0.5 }
+  let(:yesterday) { today - 1 }
+  let(:two_days_ago) { today - 2 }
+  let(:last_week) { today - 7 }
+  let(:last_year) { today << 12 }
+  let(:s3_client) { Metrics.fake_s3_client }
+
+  subject do
+    Metrics::CompletionRate.new(period: period,
+                                date: start_date.to_s)
+  end
+
+  before do
+    ENV["S3_METRICS_BUCKET"] = "stub-bucket"
+    DB[:userdetails].truncate
+    allow(Services).to receive(:s3_client).and_return s3_client
+  end
+
+  it "rejects invalid periods" do
+    expect { Metrics::CompletionRate.new(period: "foo", date: Date.today.to_s) }
+      .to raise_error(ArgumentError)
+  end
+
+  describe "#execute" do
+    before do
+      FactoryBot.create(:user_details, created_at: twelve_hours_ago)
+      FactoryBot.create(:user_details, created_at: last_week)
+      FactoryBot.create(:user_details, :not_logged_in, created_at: last_week)
+      FactoryBot.create(:user_details, :not_logged_in, created_at: last_year)
+
+      FactoryBot.create(:user_details, :sms, created_at: twelve_hours_ago)
+      FactoryBot.create(:user_details, :sms, created_at: last_week)
+      FactoryBot.create(:user_details, :sms, :not_logged_in, created_at: last_week)
+      FactoryBot.create(:user_details, :sms, :not_logged_in, created_at: last_year)
+
+      FactoryBot.create(:user_details, :self_signed, created_at: twelve_hours_ago)
+      FactoryBot.create(:user_details, :self_signed, created_at: last_week)
+      FactoryBot.create(:user_details, :not_logged_in, :self_signed, created_at: last_week)
+      FactoryBot.create(:user_details, :not_logged_in, :self_signed, created_at: last_year)
+
+      subject.execute
+
+      result = s3_client.get_object(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: subject.key).body.read
+      @parsed_result = JSON.parse(result)
+    end
+
+    describe "The start date is yesterday and the period is a month" do
+      let(:start_date) { yesterday }
+      let(:period) { "month" }
+
+      it "uploads information that 2 sms registered users were created within a month before yesterday" do
+        expect(@parsed_result["sms_registered"]).to eq(2)
+      end
+
+      it "uploads information that 1 sms registered user was created within a month before yesterday who logged in" do
+        expect(@parsed_result["sms_logged_in"]).to eq(1)
+      end
+
+      it "uploads information that 2 email registered users were created within a month before yesterday" do
+        expect(@parsed_result["email_registered"]).to eq(2)
+      end
+
+      it "uploads information that 1 email registered user was created before yesterday within a month who logged in" do
+        expect(@parsed_result["email_logged_in"]).to eq(1)
+      end
+
+      it "uploads information that 2 sponsored users were created before yesterday within a month" do
+        expect(@parsed_result["sponsor_registered"]).to eq(2)
+      end
+
+      it "uploads information that 1 sponsored user was created before yesterday who logged in" do
+        expect(@parsed_result["sponsor_logged_in"]).to eq(1)
+      end
+    end
+  end
+end

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -47,12 +47,15 @@ PERIODS.each do |adverbial, period|
 
     logger.info("Creating #{adverbial} metrics for S3 with #{args[:date]}")
 
-    metrics = Metrics::Volumetrics.new(period: period, date: args[:date])
+    metrics_list = [Metrics::Volumetrics.new(period: period, date: args[:date]),
+                    Metrics::CompletionRate.new(period: period, date: args[:date])]
 
-    logger.info("[#{metrics.key}] Fetching and uploading metrics...")
+    metrics_list.each do |metrics|
+      logger.info("[#{metrics.key}] Fetching and uploading metrics...")
 
-    metrics.execute
+      metrics.execute
 
-    logger.info("[#{metrics.key}] Done.")
+      logger.info("[#{metrics.key}] Done.")
+    end
   end
 end


### PR DESCRIPTION
Upload Completion Rate metrics to S3

These metrics are currently uploaded to the Performance Platform which will shortly be retired and so in order to preserve these datapoints we upload them to S3 instead.