### PR TITLE
Revert "Remove rake tasks and code to send stats to the performance platform"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ These get stored and sent to the user.
 - `POST /user-signup/email-notification` - AWS SES incoming email notifications
 - `POST /user-signup/sms-notification/notify` - Notify incoming SMS notifications
 
-## Recording statistics
+## Performance Platform
 
-This application sends statistics to the S3 for volumetrics and completion rates via a Rake task. This Rake task is triggered by an ECS scheduled task.
+This application sends statistics to the [Performance Platform][performance-platform] for volumetrics and completion rates via a Rake task. This Rake task is triggered by an ECS scheduled task.
 
 ### Send statistics manually
 
@@ -100,5 +100,6 @@ two steps:
 This codebase is released under [the MIT License][mit].
 
 [mit]: LICENCE
+[performance-platform]: https://www.gov.uk/performance/govwifi
 [notify]: https://www.notifications.service.gov.uk/
 [build-repo]: https://github.com/alphagov/govwifi-build

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -20,9 +20,11 @@ module Common
   module Gateway; end
 end
 
-module Metrics
+module PerformancePlatform
   module Gateway; end
+  module Presenter; end
   module Repository; end
+  module UseCase; end
 end
 
 module WifiUser

--- a/lib/metrics/completion_rate.rb
+++ b/lib/metrics/completion_rate.rb
@@ -20,7 +20,7 @@ module Metrics
   private
 
     def stats
-      gateway = Metrics::Gateway::CompletionRate.new(
+      gateway = PerformancePlatform::Gateway::CompletionRate.new(
         period: @period,
         date: @date,
       )

--- a/lib/metrics/volumetrics.rb
+++ b/lib/metrics/volumetrics.rb
@@ -20,7 +20,7 @@ module Metrics
   private
 
     def stats
-      gateway = Metrics::Gateway::Volumetrics.new(
+      gateway = PerformancePlatform::Gateway::Volumetrics.new(
         period: @period,
         date: @date,
       )

--- a/lib/performance_platform/gateway/completion_rate.rb
+++ b/lib/performance_platform/gateway/completion_rate.rb
@@ -1,4 +1,4 @@
-class Metrics::Gateway::CompletionRate
+class PerformancePlatform::Gateway::CompletionRate
   def initialize(date: Date.today.to_s, period: "week")
     @date = Date.parse(date)
     @period = period
@@ -22,7 +22,7 @@ private
   attr_reader :date
 
   def repository
-    Metrics::Repository::SignUp
+    PerformancePlatform::Repository::SignUp
   end
 
   def sms_registered

--- a/lib/performance_platform/gateway/performance_report.rb
+++ b/lib/performance_platform/gateway/performance_report.rb
@@ -1,0 +1,41 @@
+class PerformancePlatform::Gateway::HttpError < StandardError; end
+
+class PerformancePlatform::Gateway::PerformanceReport
+  def send_stats(data)
+    uri = build_url(data)
+
+    post(uri, data)
+  end
+
+private
+
+  def post(uri, data)
+    request = Net::HTTP::Post.new(uri)
+    request["Authorization"] = build_bearer_token(data)
+    request["Content-Type"] = "application/json"
+    request.body = data[:payload].to_json
+
+    Net::HTTP.start(uri.hostname, 443, use_ssl: true) do |http|
+      response = http.request(request)
+
+      raise PerformancePlatform::Gateway::HttpError, "#{response.code} - #{response.body}" \
+        unless response.code == "200"
+
+      JSON.parse(response.body)
+    end
+  end
+
+  def build_url(data)
+    performance_url = ENV.fetch("PERFORMANCE_URL")
+    dataset_name = ENV.fetch("PERFORMANCE_DATASET")
+    metric_name = data[:metric_name]
+
+    URI("#{performance_url}data/#{dataset_name}/#{metric_name}")
+  end
+
+  def build_bearer_token(data)
+    bearer_const_name = data[:metric_name].tr("-", "_").upcase
+
+    "Bearer #{ENV.fetch('PERFORMANCE_BEARER_' + bearer_const_name)}"
+  end
+end

--- a/lib/performance_platform/gateway/volumetrics.rb
+++ b/lib/performance_platform/gateway/volumetrics.rb
@@ -1,4 +1,4 @@
-class Metrics::Gateway::Volumetrics
+class PerformancePlatform::Gateway::Volumetrics
   attr_reader :period
 
   def initialize(date: Date.today.to_s, period: "day")
@@ -26,7 +26,7 @@ private
   attr_reader :date
 
   def repository
-    Metrics::Repository::SignUp
+    PerformancePlatform::Repository::SignUp
   end
 
   def signups_period_before

--- a/lib/performance_platform/presenter/completion_rate.rb
+++ b/lib/performance_platform/presenter/completion_rate.rb
@@ -1,0 +1,57 @@
+class PerformancePlatform::Presenter::CompletionRate
+  def initialize(date: Date.today.to_s)
+    @date = Date.parse(date)
+  end
+
+  def present(stats:)
+    @stats = stats
+    @timestamp = generate_timestamp
+
+    {
+      metric_name: stats[:metric_name],
+      payload: [
+        as_hash(stats[:sms_registered], "sms", "start"),
+        as_hash(stats[:sms_logged_in], "sms", "complete"),
+        as_hash(stats[:email_registered], "email", "start"),
+        as_hash(stats[:email_logged_in], "email", "complete"),
+        as_hash(stats[:sponsor_registered], "sponsor", "start"),
+        as_hash(stats[:sponsor_logged_in], "sponsor", "complete"),
+      ],
+    }
+  end
+
+private
+
+  attr_reader :date
+
+  def generate_timestamp
+    "#{date}T00:00:00+00:00"
+  end
+
+  def as_hash(count, channel, stage)
+    {
+      _id: encode_id(stage, channel),
+      _timestamp: timestamp,
+      dataType: stats[:metric_name],
+      period: stats[:period],
+      channel: channel,
+      stage: stage,
+      count: count,
+    }
+  end
+
+  def encode_id(stage, channel)
+    Common::Base64.encode_array(
+      [
+        timestamp,
+        ENV.fetch("PERFORMANCE_DATASET"),
+        stats[:period],
+        stats[:metric_name],
+        stage,
+        channel,
+      ],
+    )
+  end
+
+  attr_reader :stats, :timestamp
+end

--- a/lib/performance_platform/presenter/volumetrics.rb
+++ b/lib/performance_platform/presenter/volumetrics.rb
@@ -1,0 +1,54 @@
+class PerformancePlatform::Presenter::Volumetrics
+  def initialize(date: Date.today.to_s)
+    @date = Date.parse(date)
+  end
+
+  def present(stats:)
+    @stats = stats
+    @timestamp = generate_timestamp
+
+    {
+      metric_name: stats[:metric_name],
+      payload: [
+        as_hash(stats[:period_before], stats[:cumulative], "all-sign-ups"),
+        as_hash(stats[:sms_period_before], stats[:sms_cumulative], "sms-sign-ups"),
+        as_hash(stats[:email_period_before], stats[:email_cumulative], "email-sign-ups"),
+        as_hash(stats[:sponsored_period_before], stats[:sponsored_cumulative], "sponsor-sign-ups"),
+      ],
+    }
+  end
+
+private
+
+  attr_reader :date
+
+  def generate_timestamp
+    "#{date - 1}T00:00:00+00:00"
+  end
+
+  def as_hash(count, cumulative_count, channel)
+    {
+      _id: encode_id(channel),
+      _timestamp: timestamp,
+      dataType: stats[:metric_name],
+      period: stats[:period],
+      channel: channel,
+      count: count,
+      cumulative_count: cumulative_count,
+    }
+  end
+
+  def encode_id(channel)
+    Common::Base64.encode_array(
+      [
+        timestamp,
+        ENV.fetch("PERFORMANCE_DATASET"),
+        stats[:period],
+        stats[:metric_name],
+        channel,
+      ],
+    )
+  end
+
+  attr_reader :stats, :timestamp
+end

--- a/lib/performance_platform/repository/sign_up.rb
+++ b/lib/performance_platform/repository/sign_up.rb
@@ -1,4 +1,4 @@
-class Metrics::Repository::SignUp < Sequel::Model(:userdetails)
+class PerformancePlatform::Repository::SignUp < Sequel::Model(:userdetails)
   dataset_module do
     def all(date)
       where(Sequel.lit("date(created_at) <= '#{date - 1}'"))

--- a/lib/performance_platform/use_case/send_performance_report.rb
+++ b/lib/performance_platform/use_case/send_performance_report.rb
@@ -1,0 +1,21 @@
+require "logger"
+
+class PerformancePlatform::UseCase::SendPerformanceReport
+  def initialize(stats_gateway:, performance_gateway:, logger: Logger.new(STDOUT))
+    @stats_gateway = stats_gateway
+    @performance_gateway = performance_gateway
+    @logger = logger
+  end
+
+  def execute(presenter:)
+    stats = stats_gateway.fetch_stats
+    performance_data = presenter.present(stats: stats)
+    logger.info("Sending performance data: #{performance_data}")
+
+    performance_gateway.send_stats(performance_data)
+  end
+
+private
+
+  attr_reader :stats_gateway, :performance_gateway, :logger
+end

--- a/spec/unit/lib/performance_platform/gateway/completion_rate_spec.rb
+++ b/spec/unit/lib/performance_platform/gateway/completion_rate_spec.rb
@@ -1,4 +1,4 @@
-describe Metrics::Gateway::CompletionRate do
+describe PerformancePlatform::Gateway::CompletionRate do
   let(:user_repo) { WifiUser::Repository::User }
 
   before do

--- a/spec/unit/lib/performance_platform/gateway/performance_report_spec.rb
+++ b/spec/unit/lib/performance_platform/gateway/performance_report_spec.rb
@@ -1,0 +1,44 @@
+describe PerformancePlatform::Gateway::PerformanceReport do
+  let(:endpoint) { "https://performance-platform/" }
+  let(:data) { { metric_name: "volumetrics", payload: [{ foo: :bar }] } }
+
+  before do
+    ENV["PERFORMANCE_BEARER_VOLUMETRICS"] = "foobarbaz"
+    ENV["PERFORMANCE_URL"] = endpoint
+    ENV["PERFORMANCE_DATASET"] = "gov-wifi"
+
+    stub_request(:post, "#{endpoint}data/gov-wifi/volumetrics")
+    .with(
+      body: data[:payload].to_json,
+      headers: {
+        "Content-Type" => "application/json",
+        "Authorization" => "Bearer foobarbaz",
+      },
+    )
+    .to_return(
+      body: response.to_json,
+      status: response_code,
+    )
+  end
+
+  context "with valid data sent" do
+    let(:response) { { status: "ok" } }
+    let(:response_code) { 200 }
+
+    it "returns an OK response" do
+      result = subject.send_stats(data)
+
+      expect(result["status"]).to eq("ok")
+    end
+  end
+
+  context "with invalid data" do
+    let(:response) { "error message" }
+    let(:response_code) { 403 }
+
+    it "rasises an error" do
+      expect { subject.send_stats(data) }.to \
+        raise_error(PerformancePlatform::Gateway::HttpError, '403 - "error message"')
+    end
+  end
+end

--- a/spec/unit/lib/performance_platform/gateway/volumetrics_spec.rb
+++ b/spec/unit/lib/performance_platform/gateway/volumetrics_spec.rb
@@ -1,4 +1,4 @@
-describe Metrics::Gateway::Volumetrics do
+describe PerformancePlatform::Gateway::Volumetrics do
   let(:user_repository) { WifiUser::Repository::User }
 
   before do

--- a/spec/unit/lib/performance_platform/presenter/completion_rate_spec.rb
+++ b/spec/unit/lib/performance_platform/presenter/completion_rate_spec.rb
@@ -1,0 +1,58 @@
+require "timecop"
+
+describe PerformancePlatform::Presenter::CompletionRate do
+  before do
+    Timecop.freeze(Date.parse("04-04-2018"))
+  end
+
+  after do
+    Timecop.return
+  end
+
+  let(:stats) do
+    {
+      period: "week",
+      metric_name: "completion-rate",
+      sms_registered: 0,
+      sms_logged_in: 0,
+      email_registered: 0,
+      email_logged_in: 0,
+      sponsor_registered: 0,
+      sponsor_logged_in: 0,
+    }
+  end
+
+  it "presents the correct ID" do
+    expected_id = "MjAxOC0wNC0wNFQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2NvbXBsZXRpb24tcmF0ZXN0YXJ0c21z"
+    expect(subject.present(stats: stats)[:payload].first).to include(
+      _id: expected_id,
+      _timestamp: "2018-04-04T00:00:00+00:00",
+    )
+  end
+
+  context "Given a date override" do
+    subject { described_class.new(date: "04-04-2018") }
+
+    context "Same date as today" do
+      it "does not change the identifier" do
+        expected_id = "MjAxOC0wNC0wNFQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2NvbXBsZXRpb24tcmF0ZXN0YXJ0c21z"
+        expect(subject.present(stats: stats)[:payload].first).to include(
+          _id: expected_id,
+          _timestamp: "2018-04-04T00:00:00+00:00",
+        )
+      end
+    end
+
+    context "Given a different date to override" do
+      subject { described_class.new(date: "05-04-2018") }
+
+      it "changes the identifier" do
+        expected_id = "MjAxOC0wNC0wNVQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2NvbXBsZXRpb24tcmF0ZXN0YXJ0c21z"
+        expect(subject.present(stats: stats)[:payload].first).to include(
+          _id: expected_id,
+          _timestamp: "2018-04-05T00:00:00+00:00",
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/lib/performance_platform/presenter/volumetrics_spec.rb
+++ b/spec/unit/lib/performance_platform/presenter/volumetrics_spec.rb
@@ -1,0 +1,60 @@
+require "timecop"
+
+describe PerformancePlatform::Presenter::Volumetrics do
+  before do
+    Timecop.freeze(Date.parse("04-04-2018"))
+  end
+
+  after do
+    Timecop.return
+  end
+
+  let(:stats) do
+    {
+      period: "day",
+      metric_name: "volumetrics",
+      period_before: 0,
+      cumulative: 0,
+      sms_period_before: 0,
+      sms_cumulative: 0,
+      email_period_before: 0,
+      email_cumulative: 0,
+      sponsored_period_before: 0,
+      sponsored_cumulative: 0,
+    }
+  end
+
+  it "presents the correct ID" do
+    expected_id = "MjAxOC0wNC0wM1QwMDowMDowMCswMDowMGdvdi13aWZpZGF5dm9sdW1ldHJpY3NhbGwtc2lnbi11cHM="
+    expect(subject.present(stats: stats)[:payload].first).to include(
+      _id: expected_id,
+      _timestamp: "2018-04-03T00:00:00+00:00",
+    )
+  end
+
+  context "Given a date override" do
+    subject { described_class.new(date: "04-04-2018") }
+
+    context "Same date as today" do
+      it "does not change the identifier" do
+        expected_id = "MjAxOC0wNC0wM1QwMDowMDowMCswMDowMGdvdi13aWZpZGF5dm9sdW1ldHJpY3NhbGwtc2lnbi11cHM="
+        expect(subject.present(stats: stats)[:payload].first).to include(
+          _id: expected_id,
+          _timestamp: "2018-04-03T00:00:00+00:00",
+        )
+      end
+    end
+
+    context "Given a different date to override" do
+      subject { described_class.new(date: "05-04-2018") }
+
+      it "changes the identifier" do
+        expected_id = "MjAxOC0wNC0wNFQwMDowMDowMCswMDowMGdvdi13aWZpZGF5dm9sdW1ldHJpY3NhbGwtc2lnbi11cHM="
+        expect(subject.present(stats: stats)[:payload].first).to include(
+          _id: expected_id,
+          _timestamp: "2018-04-04T00:00:00+00:00",
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/lib/performance_platform/use_case/send_performance_report_spec.rb
+++ b/spec/unit/lib/performance_platform/use_case/send_performance_report_spec.rb
@@ -1,0 +1,262 @@
+describe PerformancePlatform::UseCase::SendPerformanceReport do
+  let(:performance_gateway) { PerformancePlatform::Gateway::PerformanceReport.new }
+  let(:endpoint) { "https://performance-platform/" }
+  let(:response) { { status: "ok" } }
+
+  before do
+    allow(presenter).to receive(:generate_timestamp).and_return("2018-07-16T00:00:00+00:00")
+
+    expect(stats_gateway).to receive(:fetch_stats)
+      .and_return(stats_gateway_response)
+
+    ENV["PERFORMANCE_BEARER_VOLUMETRICS"] = "foobarbaz"
+    ENV["PERFORMANCE_BEARER_COMPLETION_RATE"] = "googoogoo"
+    ENV["PERFORMANCE_URL"] = endpoint
+    ENV["PERFORMANCE_DATASET"] = dataset
+
+    stub_request(:post, "#{endpoint}data/#{dataset}/#{metric}")
+    .with(
+      body: data[:payload].to_json,
+      headers: {
+        "Content-Type" => "application/json",
+        "Authorization" => "Bearer #{bearer_token}",
+      },
+    )
+    .to_return(
+      body: response.to_json,
+      status: 200,
+    )
+  end
+
+  subject do
+    described_class.new(
+      stats_gateway: stats_gateway,
+      performance_gateway: performance_gateway,
+      logger: double(info: ""),
+    )
+  end
+
+  context "report for volumetrics" do
+    let(:metric) { "volumetrics" }
+    let(:bearer_token) { "foobarbaz" }
+    let(:dataset) { "gov-wifi" }
+    let(:presenter) { PerformancePlatform::Presenter::Volumetrics.new }
+
+    context "daily" do
+      let(:stats_gateway) { PerformancePlatform::Gateway::Volumetrics.new(period: "day") }
+      let(:stats_gateway_response) do
+        {
+          metric_name: "volumetrics",
+          period: "day",
+          period_before: 12,
+          cumulative: 24,
+          sms_period_before: 2,
+          sms_cumulative: 3,
+          email_period_before: 10,
+          email_cumulative: 21,
+          sponsored_period_before: 7,
+          sponsored_cumulative: 9,
+        }
+      end
+      let(:data) do
+        {
+          metric_name: "volumetrics",
+          payload: [
+            {
+              _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpZGF5dm9sdW1ldHJpY3NhbGwtc2lnbi11cHM=",
+              _timestamp: "2018-07-16T00:00:00+00:00",
+              dataType: "volumetrics",
+              period: "day",
+              channel: "all-sign-ups",
+              count: 12,
+              cumulative_count: 24,
+            },
+            {
+              _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpZGF5dm9sdW1ldHJpY3NzbXMtc2lnbi11cHM=",
+              _timestamp: "2018-07-16T00:00:00+00:00",
+              dataType: "volumetrics",
+              period: "day",
+              channel: "sms-sign-ups",
+              count: 2,
+              cumulative_count: 3,
+            },
+            {
+              _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpZGF5dm9sdW1ldHJpY3NlbWFpbC1zaWduLXVwcw==",
+              _timestamp: "2018-07-16T00:00:00+00:00",
+              dataType: "volumetrics",
+              period: "day",
+              channel: "email-sign-ups",
+              count: 10,
+              cumulative_count: 21,
+            },
+            {
+              _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpZGF5dm9sdW1ldHJpY3NzcG9uc29yLXNpZ24tdXBz",
+              _timestamp: "2018-07-16T00:00:00+00:00",
+              dataType: "volumetrics",
+              period: "day",
+              channel: "sponsor-sign-ups",
+              count: 7,
+              cumulative_count: 9,
+            },
+          ],
+        }
+      end
+
+      it "fetches stats and sends them to Performance service" do
+        expect(subject.execute(presenter: presenter)["status"]).to eq("ok")
+      end
+    end
+
+    context "monthly" do
+      let(:stats_gateway) { PerformancePlatform::Gateway::Volumetrics.new(period: "month") }
+      let(:stats_gateway_response) do
+        {
+          metric_name: "volumetrics",
+          period: "month",
+          period_before: 12,
+          cumulative: 24,
+          sms_period_before: 2,
+          sms_cumulative: 3,
+          email_period_before: 10,
+          email_cumulative: 21,
+          sponsored_period_before: 7,
+          sponsored_cumulative: 9,
+        }
+      end
+      let(:data) do
+        {
+          metric_name: "volumetrics",
+          payload: [
+            {
+              _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpbW9udGh2b2x1bWV0cmljc2FsbC1zaWduLXVwcw==",
+              _timestamp: "2018-07-16T00:00:00+00:00",
+              dataType: "volumetrics",
+              period: "month",
+              channel: "all-sign-ups",
+              count: 12,
+              cumulative_count: 24,
+            },
+            {
+              _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpbW9udGh2b2x1bWV0cmljc3Ntcy1zaWduLXVwcw==",
+              _timestamp: "2018-07-16T00:00:00+00:00",
+              dataType: "volumetrics",
+              period: "month",
+              channel: "sms-sign-ups",
+              count: 2,
+              cumulative_count: 3,
+            },
+            {
+              _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpbW9udGh2b2x1bWV0cmljc2VtYWlsLXNpZ24tdXBz",
+              _timestamp: "2018-07-16T00:00:00+00:00",
+              dataType: "volumetrics",
+              period: "month",
+              channel: "email-sign-ups",
+              count: 10,
+              cumulative_count: 21,
+            },
+            {
+              _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpbW9udGh2b2x1bWV0cmljc3Nwb25zb3Itc2lnbi11cHM=",
+              _timestamp: "2018-07-16T00:00:00+00:00",
+              dataType: "volumetrics",
+              period: "month",
+              channel: "sponsor-sign-ups",
+              count: 7,
+              cumulative_count: 9,
+            },
+          ],
+        }
+      end
+
+      it "fetches stats and sends them to Performance service" do
+        expect(subject.execute(presenter: presenter)["status"]).to eq("ok")
+      end
+    end
+  end
+
+  context "report for completion rates" do
+    let(:metric) { "completion-rate" }
+    let(:bearer_token) { "googoogoo" }
+    let(:dataset) { "gov-wifi" }
+    let(:presenter) { PerformancePlatform::Presenter::CompletionRate.new }
+    let(:stats_gateway) { PerformancePlatform::Gateway::CompletionRate.new }
+    let(:stats_gateway_response) do
+      {
+        metric_name: "completion-rate",
+        period: "week",
+        sms_registered: 4,
+        sms_logged_in: 2,
+        email_registered: 2,
+        email_logged_in: 1,
+        sponsor_registered: 2,
+        sponsor_logged_in: 1,
+      }
+    end
+
+    let(:data) do
+      {
+        metric_name: "completion-rate",
+        payload: [
+          {
+            _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2NvbXBsZXRpb24tcmF0ZXN0YXJ0c21z",
+            _timestamp: "2018-07-16T00:00:00+00:00",
+            dataType: "completion-rate",
+            period: "week",
+            channel: "sms",
+            stage: "start",
+            count: 4,
+          },
+          {
+            _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2NvbXBsZXRpb24tcmF0ZWNvbXBsZXRlc21z",
+            _timestamp: "2018-07-16T00:00:00+00:00",
+            dataType: "completion-rate",
+            period: "week",
+            channel: "sms",
+            stage: "complete",
+            count: 2,
+          },
+          {
+            _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2NvbXBsZXRpb24tcmF0ZXN0YXJ0ZW1haWw=",
+            _timestamp: "2018-07-16T00:00:00+00:00",
+            dataType: "completion-rate",
+            period: "week",
+            channel: "email",
+            stage: "start",
+            count: 2,
+          },
+          {
+            _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2NvbXBsZXRpb24tcmF0ZWNvbXBsZXRlZW1haWw=",
+            _timestamp: "2018-07-16T00:00:00+00:00",
+            dataType: "completion-rate",
+            period: "week",
+            channel: "email",
+            stage: "complete",
+            count: 1,
+          },
+          {
+            _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2NvbXBsZXRpb24tcmF0ZXN0YXJ0c3BvbnNvcg==",
+            _timestamp: "2018-07-16T00:00:00+00:00",
+            dataType: "completion-rate",
+            period: "week",
+            channel: "sponsor",
+            stage: "start",
+            count: 2,
+          },
+          {
+
+            _id: "MjAxOC0wNy0xNlQwMDowMDowMCswMDowMGdvdi13aWZpd2Vla2NvbXBsZXRpb24tcmF0ZWNvbXBsZXRlc3BvbnNvcg==",
+            _timestamp: "2018-07-16T00:00:00+00:00",
+            dataType: "completion-rate",
+            period: "week",
+            channel: "sponsor",
+            stage: "complete",
+            count: 1,
+          },
+        ],
+      }
+    end
+
+    it "fetches stats and sends them to Performance service" do
+      expect(subject.execute(presenter: presenter)["status"]).to eq("ok")
+    end
+  end
+end

--- a/tasks/publish_statistics.rb
+++ b/tasks/publish_statistics.rb
@@ -8,6 +8,36 @@ PERIODS = {
 }.freeze
 
 PERIODS.each do |adverbial, period|
+  name = "publish_#{adverbial}_statistics".to_sym
+
+  task name, [:date] do |_, args|
+    require "./lib/loader"
+
+    args.with_defaults(date: Date.today.to_s)
+    logger.info("Publishing #{adverbial} statistics with #{args[:date]}")
+    performance_gateway = PerformancePlatform::Gateway::PerformanceReport.new
+
+    if period != "week"
+      volumetrics_gateway = PerformancePlatform::Gateway::Volumetrics.new(date: args[:date], period: period)
+      volumetrics_presenter = PerformancePlatform::Presenter::Volumetrics.new(date: args[:date])
+
+      PerformancePlatform::UseCase::SendPerformanceReport.new(
+        stats_gateway: volumetrics_gateway,
+        performance_gateway: performance_gateway,
+      ).execute(presenter: volumetrics_presenter)
+    end
+
+    completion_rate_gateway = PerformancePlatform::Gateway::CompletionRate.new(date: args[:date], period: period)
+    completion_rate_presenter = PerformancePlatform::Presenter::CompletionRate.new(date: args[:date])
+
+    PerformancePlatform::UseCase::SendPerformanceReport.new(
+      stats_gateway: completion_rate_gateway,
+      performance_gateway: performance_gateway,
+    ).execute(presenter: completion_rate_presenter)
+  end
+end
+
+PERIODS.each do |adverbial, period|
   name = "publish_#{adverbial}_metrics".to_sym
 
   task name, [:date] do |_, args|


### PR DESCRIPTION
Reverts alphagov/govwifi-user-signup-api#387

We're going to remove these rake tasks later as PP retirement is currently put on hold for sometime.