### PR TITLE
Reset RACK_ENV in specs where it's overridden

### DIFF
--- a/spec/acceptance/sms_notification_spec.rb
+++ b/spec/acceptance/sms_notification_spec.rb
@@ -45,18 +45,30 @@ RSpec.describe App do
       end
 
       context "production" do
-        it "uses the rack environment variable" do
+        before do
           ENV["RACK_ENV"] = "production"
+        end
 
+        after do
+          ENV["RACK_ENV"] = "test"
+        end
+
+        it "uses the rack environment variable" do
           expect(WifiUser::UseCase::SmsTemplateFinder).to receive(:new).with(environment: "production")
           post_sms_notification
         end
       end
 
       context "staging" do
-        it "uses the rack environment variable" do
+        before do
           ENV["RACK_ENV"] = "staging"
+        end
 
+        after do
+          ENV["RACK_ENV"] = "test"
+        end
+
+        it "uses the rack environment variable" do
           expect(WifiUser::UseCase::SmsTemplateFinder).to receive(:new).with(environment: "staging")
           post_sms_notification
         end

--- a/spec/features/sms_spec.rb
+++ b/spec/features/sms_spec.rb
@@ -22,6 +22,10 @@ describe App do
       stub_request(:post, notify_sms_url).to_return(status: 200, body: {}.to_json)
     end
 
+    after do
+      ENV["RACK_ENV"] = "test"
+    end
+
     it "sends an SMS containing login details back to the user" do
       post "/user-signup/sms-notification/notify",
            payload,

--- a/spec/lib/wifi_user/use_cases/email_signup_spec.rb
+++ b/spec/lib/wifi_user/use_cases/email_signup_spec.rb
@@ -39,6 +39,10 @@ describe WifiUser::UseCase::EmailSignup do
         .and_return(username: username, password: password)
     end
 
+    after do
+      ENV["RACK_ENV"] = "test"
+    end
+
     context "in the production environment" do
       let(:environment) { "production" }
       let(:notify_template_id) { "f18708c0-e857-4f62-b5f3-8f0c75fc2fdb" }


### PR DESCRIPTION
In some tests, `ENV["RACK_ENV"]` is overridden to `staging` or `production`
either in a `before` block or inline.

ENV is not reset between tests, so any subsequent tests requiring `RACK_ENV`
to be `test` will then fail.

This change moves inlines to `before` blocks, and adds an `after` block
to reset back to `test`.

This has come up as part of the survey work, however it seems worth isolating in a separate PR.