### PR TITLE
Automate user signup survey part 2

### DIFF
--- a/config/test.yml
+++ b/config/test.yml
@@ -8,7 +8,7 @@ notify_sms_template_ids:
     mac: fff
     iphone: ggg
     windows: hhh
-  active_users_signup_survey: mobile-mock-template
+  active_users_signup_survey: active-users-mobile-signup-survey-template
 
 notify_email_template_ids:
   self_signup_credentials: iii
@@ -17,6 +17,6 @@ notify_email_template_ids:
     plural: kkk
     singular: lll
     failed: mmm
-  active_users_signup_survey: email-mock-template
+  active_users_signup_survey: active-users-email-signup-survey-template
 
 do_not_reply_email_id: nnn

--- a/config/test.yml
+++ b/config/test.yml
@@ -9,6 +9,7 @@ notify_sms_template_ids:
     iphone: ggg
     windows: hhh
   active_users_signup_survey: active-users-mobile-signup-survey-template
+  inactive_users_signup_survey: inactive-users-mobile-signup-survey-template
 
 notify_email_template_ids:
   self_signup_credentials: iii
@@ -18,5 +19,6 @@ notify_email_template_ids:
     singular: lll
     failed: mmm
   active_users_signup_survey: active-users-email-signup-survey-template
+  inactive_users_signup_survey: inactive-users-email-signup-survey-template
 
 do_not_reply_email_id: nnn

--- a/lib/survey/gateway/notifications.rb
+++ b/lib/survey/gateway/notifications.rb
@@ -1,11 +1,10 @@
 require "notifications/client"
 
 class Survey::Gateway::Notifications
-  def initialize
+  def initialize(key)
     @client = Notifications::Client.new(ENV.fetch("NOTIFY_API_KEY"))
 
     config = YAML.load_file("config/#{ENV['RACK_ENV']}.yml")
-    key = "active_users_signup_survey"
 
     @email_template_id = config["notify_email_template_ids"][key]
     @mobile_template_id = config["notify_sms_template_ids"][key]

--- a/lib/survey/gateway/user_details.rb
+++ b/lib/survey/gateway/user_details.rb
@@ -1,23 +1,31 @@
 require "logger"
 
 class Survey::Gateway::UserDetails
-  def fetch
-    all = WifiUser::Repository::User
-            .where { created_at > Time.now - 1 * 3600 * 24 }
-            .where { contact =~ sponsor }
-            .exclude(last_login: nil)
-            .where(signup_survey_sent_at: nil)
+  def fetch_for_active
+    fetch WifiUser::Repository::User
+      .where { created_at > (Date.today - 1).to_time }
+      .where { created_at <= (Date.today).to_time }
+      .where { contact =~ sponsor }
+      .exclude(last_login: nil)
+      .where(signup_survey_sent_at: nil)
+  end
 
-    total = all.count
 
-    if total.zero?
-      all
-    else
-      all.limit((total * 0.25).ceil)
-    end
   end
 
   def mark_as_sent(query)
     query.update(signup_survey_sent_at: Time.now)
+  end
+
+  private
+
+  def fetch(query)
+    total = query.count
+
+    if total.zero?
+      query
+    else
+      query.limit((total * 0.25).ceil)
+    end
   end
 end

--- a/lib/survey/gateway/user_details.rb
+++ b/lib/survey/gateway/user_details.rb
@@ -10,6 +10,13 @@ class Survey::Gateway::UserDetails
       .where(signup_survey_sent_at: nil)
   end
 
+  def fetch_for_inactive
+    fetch WifiUser::Repository::User
+      .where { created_at > (Date.today - 14).to_time }
+      .where { created_at <= (Date.today - 13).to_time }
+      .where { contact =~ sponsor }
+      .where(last_login: nil)
+      .where(signup_survey_sent_at: nil)
 
   end
 

--- a/lib/survey/gateway/user_details.rb
+++ b/lib/survey/gateway/user_details.rb
@@ -4,7 +4,7 @@ class Survey::Gateway::UserDetails
   def fetch_active
     limit WifiUser::Repository::User
       .where { created_at > (Date.today - 1).to_time }
-      .where { created_at <= (Date.today).to_time }
+      .where { created_at <= Date.today.to_time }
       .where { contact =~ sponsor }
       .exclude(last_login: nil)
       .where(signup_survey_sent_at: nil)
@@ -17,14 +17,13 @@ class Survey::Gateway::UserDetails
       .where { contact =~ sponsor }
       .where(last_login: nil)
       .where(signup_survey_sent_at: nil)
-
   end
 
   def mark_as_sent(query)
     query.update(signup_survey_sent_at: Time.now)
   end
 
-  private
+private
 
   def limit(query)
     total = query.count

--- a/lib/survey/gateway/user_details.rb
+++ b/lib/survey/gateway/user_details.rb
@@ -1,8 +1,8 @@
 require "logger"
 
 class Survey::Gateway::UserDetails
-  def fetch_for_active
-    fetch WifiUser::Repository::User
+  def fetch_active
+    limit WifiUser::Repository::User
       .where { created_at > (Date.today - 1).to_time }
       .where { created_at <= (Date.today).to_time }
       .where { contact =~ sponsor }
@@ -10,8 +10,8 @@ class Survey::Gateway::UserDetails
       .where(signup_survey_sent_at: nil)
   end
 
-  def fetch_for_inactive
-    fetch WifiUser::Repository::User
+  def fetch_inactive
+    limit WifiUser::Repository::User
       .where { created_at > (Date.today - 14).to_time }
       .where { created_at <= (Date.today - 13).to_time }
       .where { contact =~ sponsor }
@@ -26,7 +26,7 @@ class Survey::Gateway::UserDetails
 
   private
 
-  def fetch(query)
+  def limit(query)
     total = query.count
 
     if total.zero?

--- a/lib/survey/use_case/send_active_user_surveys.rb
+++ b/lib/survey/use_case/send_active_user_surveys.rb
@@ -8,7 +8,7 @@ class Survey::UseCase::SendActiveUserSurveys
   end
 
   def execute
-    users = user_details_gateway.fetch_for_active
+    users = user_details_gateway.fetch_active
 
     @logger.info("[active-users-signup-survey] sending email to #{users.count} users.")
 

--- a/lib/survey/use_case/send_active_user_surveys.rb
+++ b/lib/survey/use_case/send_active_user_surveys.rb
@@ -1,6 +1,6 @@
 require "logger"
 
-class Survey::UseCase::SendSurveys
+class Survey::UseCase::SendActiveUserSurveys
   def initialize(user_details_gateway:, notifications_gateway:)
     @user_details_gateway = user_details_gateway
     @notifications_gateway = notifications_gateway
@@ -8,7 +8,7 @@ class Survey::UseCase::SendSurveys
   end
 
   def execute
-    users = user_details_gateway.fetch
+    users = user_details_gateway.fetch_for_active
 
     @logger.info("[active-users-signup-survey] sending email to #{users.count} users.")
 

--- a/lib/survey/use_case/send_inactive_user_surveys.rb
+++ b/lib/survey/use_case/send_inactive_user_surveys.rb
@@ -1,0 +1,23 @@
+require "logger"
+
+class Survey::UseCase::SendInactiveUserSurveys
+  def initialize(user_details_gateway:, notifications_gateway:)
+    @user_details_gateway = user_details_gateway
+    @notifications_gateway = notifications_gateway
+    @logger = Logger.new(STDOUT)
+  end
+
+  def execute
+    users = user_details_gateway.fetch_for_inactive
+
+    @logger.info("[inactive-users-signup-survey] sending email to #{users.count} users.")
+
+    users.each do |user|
+      @notifications_gateway.execute(user)
+    end
+
+    user_details_gateway.mark_as_sent(users)
+  end
+
+  attr_reader :user_details_gateway, :notifications_gateway
+end

--- a/lib/survey/use_case/send_inactive_user_surveys.rb
+++ b/lib/survey/use_case/send_inactive_user_surveys.rb
@@ -8,7 +8,7 @@ class Survey::UseCase::SendInactiveUserSurveys
   end
 
   def execute
-    users = user_details_gateway.fetch_for_inactive
+    users = user_details_gateway.fetch_inactive
 
     @logger.info("[inactive-users-signup-survey] sending email to #{users.count} users.")
 

--- a/spec/factories/user_details.rb
+++ b/spec/factories/user_details.rb
@@ -66,5 +66,13 @@ FactoryBot.define do
     trait :inactive do
       last_login { nil }
     end
+
+    trait :idle_survey_target do
+      created_at { (Date.today - 14).to_time + 12 * 3600 }
+    end
+
+    trait :old do
+      created_at { (Date.today - 15).to_time + 12 * 3600 }
+    end
   end
 end

--- a/spec/lib/survey/gateway/notifications_spec.rb
+++ b/spec/lib/survey/gateway/notifications_spec.rb
@@ -3,7 +3,7 @@ describe Survey::Gateway::Notifications, :focus do
   let(:notify_mobile_url) { "https://api.notifications.service.gov.uk/v2/notifications/sms" }
 
   context "active user survey" do
-    let(:subject) { Survey::Gateway::Notifications.new('active_users_signup_survey') }
+    let(:subject) { Survey::Gateway::Notifications.new("active_users_signup_survey") }
 
     let(:user) { FactoryBot.create(:user_details) }
     let(:mobile_user) { FactoryBot.create(:user_details, :sms) }
@@ -57,11 +57,10 @@ describe Survey::Gateway::Notifications, :focus do
         expect(notify_mobile_stub).to have_been_requested.once
       end
     end
-
   end
 
   context "inactive user survey" do
-    let(:subject) { Survey::Gateway::Notifications.new('inactive_users_signup_survey') }
+    let(:subject) { Survey::Gateway::Notifications.new("inactive_users_signup_survey") }
 
     let(:user) { FactoryBot.create(:user_details) }
     let(:mobile_user) { FactoryBot.create(:user_details, :sms) }
@@ -115,6 +114,5 @@ describe Survey::Gateway::Notifications, :focus do
         expect(notify_mobile_stub).to have_been_requested.once
       end
     end
-
   end
 end

--- a/spec/lib/survey/gateway/notifications_spec.rb
+++ b/spec/lib/survey/gateway/notifications_spec.rb
@@ -8,14 +8,14 @@ describe Survey::Gateway::Notifications do
   let(:notify_email_request) do
     {
       email_address: user.contact,
-      template_id: "email-mock-template",
+      template_id: "active-users-email-signup-survey-template",
     }
   end
 
   let(:notify_mobile_request) do
     {
       phone_number: mobile_user.contact,
-      template_id: "mobile-mock-template",
+      template_id: "active-users-mobile-signup-survey-template",
     }
   end
 

--- a/spec/lib/survey/gateway/notifications_spec.rb
+++ b/spec/lib/survey/gateway/notifications_spec.rb
@@ -1,59 +1,120 @@
 describe Survey::Gateway::Notifications, :focus do
-  let(:subject) { Survey::Gateway::Notifications.new('active_users_signup_survey') }
-
-  let(:user) { FactoryBot.create(:user_details) }
-  let(:mobile_user) { FactoryBot.create(:user_details, :sms) }
-
   let(:notify_email_url) { "https://api.notifications.service.gov.uk/v2/notifications/email" }
   let(:notify_mobile_url) { "https://api.notifications.service.gov.uk/v2/notifications/sms" }
 
-  let(:notify_email_request) do
-    {
-      email_address: user.contact,
-      template_id: "active-users-email-signup-survey-template",
-    }
+  context "active user survey" do
+    let(:subject) { Survey::Gateway::Notifications.new('active_users_signup_survey') }
+
+    let(:user) { FactoryBot.create(:user_details) }
+    let(:mobile_user) { FactoryBot.create(:user_details, :sms) }
+
+    context "when the user signed up via email" do
+      let(:notify_email_request) do
+        {
+          email_address: user.contact,
+          template_id: "active-users-email-signup-survey-template",
+        }
+      end
+
+      let(:notify_email_stub) do
+        stub_request(:post, notify_email_url)
+          .with(body: notify_email_request)
+          .to_return(status: 200, body: {}.to_json)
+      end
+
+      before do
+        notify_email_stub
+      end
+
+      it "sends an email to them" do
+        subject.execute(user)
+
+        expect(notify_email_stub).to have_been_requested.times(1)
+      end
+    end
+
+    context "when the user signed up via mobile" do
+      let(:notify_mobile_request) do
+        {
+          phone_number: mobile_user.contact,
+          template_id: "active-users-mobile-signup-survey-template",
+        }
+      end
+
+      let(:notify_mobile_stub) do
+        stub_request(:post, notify_mobile_url)
+          .with(body: notify_mobile_request)
+          .to_return(status: 200, body: {}.to_json)
+      end
+
+      before do
+        notify_mobile_stub
+      end
+
+      it "sends a text to them" do
+        subject.execute(mobile_user)
+
+        expect(notify_mobile_stub).to have_been_requested.once
+      end
+    end
+
   end
 
-  let(:notify_mobile_request) do
-    {
-      phone_number: mobile_user.contact,
-      template_id: "active-users-mobile-signup-survey-template",
-    }
-  end
+  context "inactive user survey" do
+    let(:subject) { Survey::Gateway::Notifications.new('inactive_users_signup_survey') }
 
-  context "when the user signed up via email" do
-    let(:notify_email_stub) do
-      stub_request(:post, notify_email_url)
-        .with(body: notify_email_request)
-        .to_return(status: 200, body: {}.to_json)
+    let(:user) { FactoryBot.create(:user_details) }
+    let(:mobile_user) { FactoryBot.create(:user_details, :sms) }
+
+    context "when the user signed up via email" do
+      let(:notify_email_request) do
+        {
+          email_address: user.contact,
+          template_id: "inactive-users-email-signup-survey-template",
+        }
+      end
+
+      let(:notify_email_stub) do
+        stub_request(:post, notify_email_url)
+          .with(body: notify_email_request)
+          .to_return(status: 200, body: {}.to_json)
+      end
+
+      before do
+        notify_email_stub
+      end
+
+      it "sends an email to them" do
+        subject.execute(user)
+
+        expect(notify_email_stub).to have_been_requested.times(1)
+      end
     end
 
-    before do
-      notify_email_stub
+    context "when the user signed up via mobile" do
+      let(:notify_mobile_request) do
+        {
+          phone_number: mobile_user.contact,
+          template_id: "inactive-users-mobile-signup-survey-template",
+        }
+      end
+
+      let(:notify_mobile_stub) do
+        stub_request(:post, notify_mobile_url)
+          .with(body: notify_mobile_request)
+          .to_return(status: 200, body: {}.to_json)
+      end
+
+      before do
+        notify_mobile_stub
+      end
+
+      it "sends a text to them" do
+        subject.execute(mobile_user)
+
+        expect(notify_mobile_stub).to have_been_requested.once
+      end
     end
 
-    it "sends an email to them" do
-      subject.execute(user)
-
-      expect(notify_email_stub).to have_been_requested.times(1)
-    end
-  end
-
-  context "when the user signed up via mobile" do
-    let(:notify_mobile_stub) do
-      stub_request(:post, notify_mobile_url)
-        .with(body: notify_mobile_request)
-        .to_return(status: 200, body: {}.to_json)
-    end
-
-    before do
-      notify_mobile_stub
-    end
-
-    it "sends a text to them" do
-      subject.execute(mobile_user)
-
-      expect(notify_mobile_stub).to have_been_requested.once
-    end
   end
 end

--- a/spec/lib/survey/gateway/notifications_spec.rb
+++ b/spec/lib/survey/gateway/notifications_spec.rb
@@ -1,4 +1,6 @@
-describe Survey::Gateway::Notifications do
+describe Survey::Gateway::Notifications, :focus do
+  let(:subject) { Survey::Gateway::Notifications.new('active_users_signup_survey') }
+
   let(:user) { FactoryBot.create(:user_details) }
   let(:mobile_user) { FactoryBot.create(:user_details, :sms) }
 

--- a/spec/lib/survey/gateway/user_details_spec.rb
+++ b/spec/lib/survey/gateway/user_details_spec.rb
@@ -151,7 +151,6 @@ describe Survey::Gateway::UserDetails do
         end
       end
     end
-
   end
 
   describe "#mark_as_sent" do

--- a/spec/lib/survey/gateway/user_details_spec.rb
+++ b/spec/lib/survey/gateway/user_details_spec.rb
@@ -5,7 +5,7 @@ describe Survey::Gateway::UserDetails do
     user_details.delete
   end
 
-  describe "#fetch" do
+  describe "#fetch_for_active" do
     context "when the user has been created in the last 24 hours" do
       context "but has not logged in" do
         let(:recent_inactive_user) do
@@ -18,7 +18,7 @@ describe Survey::Gateway::UserDetails do
         end
 
         it "does not include them" do
-          expect(subject.fetch).to_not include(recent_inactive_user)
+          expect(subject.fetch_for_active).to_not include(recent_inactive_user)
         end
       end
 
@@ -33,7 +33,7 @@ describe Survey::Gateway::UserDetails do
         end
 
         it "includes them" do
-          expect(subject.fetch).to include(recent_user)
+          expect(subject.fetch_for_active).to include(recent_user)
         end
 
         it "only returns 25% of users" do
@@ -45,13 +45,13 @@ describe Survey::Gateway::UserDetails do
             :active,
           )
 
-          expect(subject.fetch.count).to eq 26 # 25 + the :recent_user
+          expect(subject.fetch_for_active.count).to eq 26 # 25 + the :recent_user
         end
       end
     end
 
     context "when the user was created more than 24 hours ago" do
-      let!(:old_user) do
+      let!(:idle_user) do
         FactoryBot.create(
           :user_details,
           :self_signed,
@@ -61,7 +61,7 @@ describe Survey::Gateway::UserDetails do
       end
 
       it "does not include them" do
-        expect(subject.fetch).to_not include(old_user)
+        expect(subject.fetch_for_active).to_not include(idle_user)
       end
     end
 
@@ -76,7 +76,7 @@ describe Survey::Gateway::UserDetails do
       end
 
       it "does not include them" do
-        expect(subject.fetch).to_not include(surveyed_user)
+        expect(subject.fetch_for_active).to_not include(surveyed_user)
       end
     end
 
@@ -85,7 +85,7 @@ describe Survey::Gateway::UserDetails do
       let!(:sponsored_user) { FactoryBot.create(:user_details, :recent, :active, :sponsored) }
 
       it "does not include them" do
-        expect(subject.fetch).to_not include(sponsored_user)
+        expect(subject.fetch_for_active).to_not include(sponsored_user)
       end
     end
   end
@@ -94,7 +94,7 @@ describe Survey::Gateway::UserDetails do
     let!(:user) { FactoryBot.create(:user_details, :self_signed, :active) }
 
     before do
-      @query = subject.fetch
+      @query = subject.fetch_for_active
     end
 
     it "updates the survey_sent_at attribute" do

--- a/spec/lib/survey/gateway/user_details_spec.rb
+++ b/spec/lib/survey/gateway/user_details_spec.rb
@@ -5,7 +5,7 @@ describe Survey::Gateway::UserDetails do
     user_details.delete
   end
 
-  describe "#fetch_for_active" do
+  describe "#fetch_active" do
     context "when the user has been created in the last 24 hours" do
       context "but has not logged in" do
         let(:recent_inactive_user) do
@@ -18,7 +18,7 @@ describe Survey::Gateway::UserDetails do
         end
 
         it "does not include them" do
-          expect(subject.fetch_for_active).to_not include(recent_inactive_user)
+          expect(subject.fetch_active).to_not include(recent_inactive_user)
         end
       end
 
@@ -33,7 +33,7 @@ describe Survey::Gateway::UserDetails do
         end
 
         it "includes them" do
-          expect(subject.fetch_for_active).to include(recent_user)
+          expect(subject.fetch_active).to include(recent_user)
         end
 
         it "only returns 25% of users" do
@@ -45,7 +45,7 @@ describe Survey::Gateway::UserDetails do
             :active,
           )
 
-          expect(subject.fetch_for_active.count).to eq 26 # 25 + the :recent_user
+          expect(subject.fetch_active.count).to eq 26 # 25 + the :recent_user
         end
       end
     end
@@ -61,7 +61,7 @@ describe Survey::Gateway::UserDetails do
       end
 
       it "does not include them" do
-        expect(subject.fetch_for_active).to_not include(idle_user)
+        expect(subject.fetch_active).to_not include(idle_user)
       end
     end
 
@@ -76,7 +76,7 @@ describe Survey::Gateway::UserDetails do
       end
 
       it "does not include them" do
-        expect(subject.fetch_for_active).to_not include(surveyed_user)
+        expect(subject.fetch_active).to_not include(surveyed_user)
       end
     end
 
@@ -85,12 +85,12 @@ describe Survey::Gateway::UserDetails do
       let!(:sponsored_user) { FactoryBot.create(:user_details, :recent, :active, :sponsored) }
 
       it "does not include them" do
-        expect(subject.fetch_for_active).to_not include(sponsored_user)
+        expect(subject.fetch_active).to_not include(sponsored_user)
       end
     end
   end
 
-  describe "#fetch_for_inactive" do
+  describe "#fetch_inactive" do
     context "when the user has been created less than 14 days ago" do
       context "but has not logged in" do
         let(:recent_inactive_user) do
@@ -103,7 +103,7 @@ describe Survey::Gateway::UserDetails do
         end
 
         it "does not include them" do
-          expect(subject.fetch_for_inactive).to_not include(recent_inactive_user)
+          expect(subject.fetch_inactive).to_not include(recent_inactive_user)
         end
       end
     end
@@ -120,7 +120,7 @@ describe Survey::Gateway::UserDetails do
         end
 
         it "includes them" do
-          expect(subject.fetch_for_inactive).to include(idle_user)
+          expect(subject.fetch_inactive).to include(idle_user)
         end
 
         it "only returns 25% of users" do
@@ -132,7 +132,7 @@ describe Survey::Gateway::UserDetails do
             :idle_survey_target,
           )
 
-          expect(subject.fetch_for_inactive.count).to eq 26 # 25 + the :idle_user
+          expect(subject.fetch_inactive.count).to eq 26 # 25 + the :idle_user
         end
       end
 
@@ -147,7 +147,7 @@ describe Survey::Gateway::UserDetails do
         end
 
         it "does not include them" do
-          expect(subject.fetch_for_inactive).to_not include(idle_user)
+          expect(subject.fetch_inactive).to_not include(idle_user)
         end
       end
     end
@@ -158,7 +158,7 @@ describe Survey::Gateway::UserDetails do
     let!(:user) { FactoryBot.create(:user_details, :self_signed, :active) }
 
     before do
-      @query = subject.fetch_for_active
+      @query = subject.fetch_active
     end
 
     it "updates the survey_sent_at attribute" do

--- a/spec/lib/survey/use_case/send_active_user_surveys_spec.rb
+++ b/spec/lib/survey/use_case/send_active_user_surveys_spec.rb
@@ -1,5 +1,5 @@
-describe Survey::UseCase::SendSurveys do
-  let(:user_details_gateway) { double("gateway double", fetch: %i[user1 user2], mark_as_sent: nil) }
+describe Survey::UseCase::SendActiveUserSurveys do
+  let(:user_details_gateway) { double("gateway double", fetch_for_active: %i[user1 user2], mark_as_sent: nil) }
   let(:notifications_gateway) { double("notifications gateway", execute: :success) }
 
   subject do
@@ -12,7 +12,7 @@ describe Survey::UseCase::SendSurveys do
   it "calls the user_details_gateway's fetch method" do
     subject.execute
 
-    expect(user_details_gateway).to have_received(:fetch)
+    expect(user_details_gateway).to have_received(:fetch_for_active)
   end
 
   it "calls the notifications gateway with each value received" do

--- a/spec/lib/survey/use_case/send_active_user_surveys_spec.rb
+++ b/spec/lib/survey/use_case/send_active_user_surveys_spec.rb
@@ -1,5 +1,5 @@
 describe Survey::UseCase::SendActiveUserSurveys do
-  let(:user_details_gateway) { double("gateway double", fetch_for_active: %i[user1 user2], mark_as_sent: nil) }
+  let(:user_details_gateway) { double("gateway double", fetch_active: %i[user1 user2], mark_as_sent: nil) }
   let(:notifications_gateway) { double("notifications gateway", execute: :success) }
 
   subject do
@@ -12,7 +12,7 @@ describe Survey::UseCase::SendActiveUserSurveys do
   it "calls the user_details_gateway's fetch method" do
     subject.execute
 
-    expect(user_details_gateway).to have_received(:fetch_for_active)
+    expect(user_details_gateway).to have_received(:fetch_active)
   end
 
   it "calls the notifications gateway with each value received" do

--- a/spec/lib/survey/use_case/send_inactive_user_surveys.rb
+++ b/spec/lib/survey/use_case/send_inactive_user_surveys.rb
@@ -1,0 +1,33 @@
+describe Survey::UseCase::SendInactiveUserSurveys do
+  let(:user_details_gateway) { double("gateway double", fetch_for_inactive: %i[user1 user2], mark_as_sent: nil) }
+  let(:notifications_gateway) { double("notifications gateway", execute: :success) }
+
+  subject do
+    described_class.new(
+      user_details_gateway: user_details_gateway,
+      notifications_gateway: notifications_gateway,
+    )
+  end
+
+  it "calls the user_details_gateway's fetch method" do
+    subject.execute
+
+    expect(user_details_gateway).to have_received(:fetch_for_inactive)
+  end
+
+  it "calls the notifications gateway with each value received" do
+    subject.execute
+
+    expect(notifications_gateway)
+      .to have_received(:execute).with(:user1).ordered
+
+    expect(notifications_gateway)
+      .to have_received(:execute).with(:user2).ordered
+  end
+
+  it "calls the user_details_gateway's mark_as_sent method" do
+    subject.execute
+
+    expect(user_details_gateway).to have_received(:mark_as_sent).with(%i[user1 user2])
+  end
+end

--- a/spec/lib/survey/use_case/send_inactive_user_surveys.rb
+++ b/spec/lib/survey/use_case/send_inactive_user_surveys.rb
@@ -1,5 +1,5 @@
 describe Survey::UseCase::SendInactiveUserSurveys do
-  let(:user_details_gateway) { double("gateway double", fetch_for_inactive: %i[user1 user2], mark_as_sent: nil) }
+  let(:user_details_gateway) { double("gateway double", fetch_inactive: %i[user1 user2], mark_as_sent: nil) }
   let(:notifications_gateway) { double("notifications gateway", execute: :success) }
 
   subject do
@@ -12,7 +12,7 @@ describe Survey::UseCase::SendInactiveUserSurveys do
   it "calls the user_details_gateway's fetch method" do
     subject.execute
 
-    expect(user_details_gateway).to have_received(:fetch_for_inactive)
+    expect(user_details_gateway).to have_received(:fetch_inactive)
   end
 
   it "calls the notifications gateway with each value received" do

--- a/tasks/survey.rb
+++ b/tasks/survey.rb
@@ -1,18 +1,36 @@
 require "logger"
 logger = Logger.new(STDOUT)
 
-task :send_active_users_signup_survey do
-  require "./lib/loader"
+namespace :users_signup_survey do
+  task :send_active do
+    require "./lib/loader"
 
-  logger.info("[active-users-signup-survey] starting email signup task...")
+    logger.info("[active-users-signup-survey] starting email signup task...")
 
-  user_details_gateway = Survey::Gateway::UserDetails.new
-  notifications_gateway = Survey::Gateway::Notifications.new
+    user_details_gateway = Survey::Gateway::UserDetails.new
+    notifications_gateway = Survey::Gateway::Notifications.new('active_users_signup_survey')
 
-  Survey::UseCase::SendSurveys.new(
-    user_details_gateway: user_details_gateway,
-    notifications_gateway: notifications_gateway,
-  ).execute
+    Survey::UseCase::SendActiveUserSurveys.new(
+      user_details_gateway: user_details_gateway,
+      notifications_gateway: notifications_gateway,
+    ).execute
 
-  logger.info("[active-users-signup-survey] done.")
+    logger.info("[active-users-signup-survey] done.")
+  end
+
+  task :send_inactive do
+    require "./lib/loader"
+
+    logger.info("[inactive-users-signup-survey] starting email signup task...")
+
+    user_details_gateway = Survey::Gateway::UserDetails.new
+    notifications_gateway = Survey::Gateway::Notifications.new
+
+    Survey::UseCase::SendInactiveUserSurveys.new(
+      user_details_gateway: user_details_gateway,
+      notifications_gateway: notifications_gateway,
+    ).execute
+
+    logger.info("[inactive-users-signup-survey] done.")
+  end
 end

--- a/tasks/survey.rb
+++ b/tasks/survey.rb
@@ -8,7 +8,7 @@ namespace :users_signup_survey do
     logger.info("[active-users-signup-survey] starting email signup task...")
 
     user_details_gateway = Survey::Gateway::UserDetails.new
-    notifications_gateway = Survey::Gateway::Notifications.new('active_users_signup_survey')
+    notifications_gateway = Survey::Gateway::Notifications.new("active_users_signup_survey")
 
     Survey::UseCase::SendActiveUserSurveys.new(
       user_details_gateway: user_details_gateway,
@@ -24,7 +24,7 @@ namespace :users_signup_survey do
     logger.info("[inactive-users-signup-survey] starting email signup task...")
 
     user_details_gateway = Survey::Gateway::UserDetails.new
-    notifications_gateway = Survey::Gateway::Notifications.new('inactive_users_signup_survey')
+    notifications_gateway = Survey::Gateway::Notifications.new("inactive_users_signup_survey")
 
     Survey::UseCase::SendInactiveUserSurveys.new(
       user_details_gateway: user_details_gateway,

--- a/tasks/survey.rb
+++ b/tasks/survey.rb
@@ -24,7 +24,7 @@ namespace :users_signup_survey do
     logger.info("[inactive-users-signup-survey] starting email signup task...")
 
     user_details_gateway = Survey::Gateway::UserDetails.new
-    notifications_gateway = Survey::Gateway::Notifications.new
+    notifications_gateway = Survey::Gateway::Notifications.new('inactive_users_signup_survey')
 
     Survey::UseCase::SendInactiveUserSurveys.new(
       user_details_gateway: user_details_gateway,


### PR DESCRIPTION
# Description
We went to send signup surveys to:
* 25%
* of our users
* who signed up 2 weeks ago
* who have been inactive (i.e never logged in)

Once approved we'll get it to staging so we can test with real emails/phones.

Co-authored with @freesteph .
