### PR TITLE
fix: fix the factory and timing logic for the inactive users survey

### DIFF
--- a/lib/survey/gateway/user_details.rb
+++ b/lib/survey/gateway/user_details.rb
@@ -12,8 +12,8 @@ class Survey::Gateway::UserDetails
 
   def fetch_inactive
     limit WifiUser::Repository::User
-      .where { created_at > (Date.today - 14).to_time }
-      .where { created_at <= (Date.today - 13).to_time }
+      .where { created_at >= (Date.today - 14).to_time }
+      .where { created_at < (Date.today - 13).to_time }
       .where { contact =~ sponsor }
       .where(last_login: nil)
       .where(signup_survey_sent_at: nil)

--- a/spec/factories/user_details.rb
+++ b/spec/factories/user_details.rb
@@ -68,7 +68,7 @@ FactoryBot.define do
     end
 
     trait :idle_survey_target do
-      created_at { (Date.today - 14).to_time + 12 * 3600 }
+      created_at { (Date.today - 14).to_time }
     end
   end
 end

--- a/spec/lib/survey/gateway/notifications_spec.rb
+++ b/spec/lib/survey/gateway/notifications_spec.rb
@@ -1,4 +1,4 @@
-describe Survey::Gateway::Notifications, :focus do
+describe Survey::Gateway::Notifications do
   let(:notify_email_url) { "https://api.notifications.service.gov.uk/v2/notifications/email" }
   let(:notify_mobile_url) { "https://api.notifications.service.gov.uk/v2/notifications/sms" }
 


### PR DESCRIPTION
Couple of issues here:

* there was a `focus: true` in the spec;
* the created_at logic should be 14 days ago inclusive (from midnight,
i.e created_at >=) all the way *before* 13 days ago (i.e created_at
<) rather than the opposite. Effectively that's a one-second interval
we're shifting but it's semantically correct, and fails the test suite
otherwise.


