### PR TITLE
Change survey log message to say "survey" not "email"

### DIFF
--- a/lib/survey/use_case/send_active_user_surveys.rb
+++ b/lib/survey/use_case/send_active_user_surveys.rb
@@ -10,7 +10,7 @@ class Survey::UseCase::SendActiveUserSurveys
   def execute
     users = user_details_gateway.fetch_active
 
-    @logger.info("[active-users-signup-survey] sending email to #{users.count} users.")
+    @logger.info("[active-users-signup-survey] sending survey to #{users.count} users.")
 
     users.each do |user|
       @notifications_gateway.execute(user)

--- a/lib/survey/use_case/send_inactive_user_surveys.rb
+++ b/lib/survey/use_case/send_inactive_user_surveys.rb
@@ -10,7 +10,7 @@ class Survey::UseCase::SendInactiveUserSurveys
   def execute
     users = user_details_gateway.fetch_inactive
 
-    @logger.info("[inactive-users-signup-survey] sending email to #{users.count} users.")
+    @logger.info("[inactive-users-signup-survey] sending survey to #{users.count} users.")
 
     users.each do |user|
       @notifications_gateway.execute(user)


### PR DESCRIPTION
Surveys are sent via email, and SMS, and we don't know how many of which
when we log this.