### PR TITLE
Handle Notifications::Client::BadRequestError

### DIFF
--- a/lib/wifi_user/use_case/sms_response.rb
+++ b/lib/wifi_user/use_case/sms_response.rb
@@ -22,7 +22,6 @@ class WifiUser::UseCase::SmsResponse
     message = validation_errors.map { |err| err["message"] }
                                .join(", ")
     logger.warn("Failed to send email: #{message}")
-    raise Sequel::Rollback
   end
 
 private

--- a/spec/lib/wifi_user/use_cases/sms_response_spec.rb
+++ b/spec/lib/wifi_user/use_cases/sms_response_spec.rb
@@ -133,10 +133,10 @@ describe WifiUser::UseCase::SmsResponse do
         expect(user_model).to receive(:generate).with(contact: phone_number).and_return(username: username, password: password)
       end
 
-      it "raises Sequel::Rollback" do
+      it "doesn't raise error" do
         expect {
           subject.execute(contact: "447700900003", sms_content: "")
-        }.to raise_error(Sequel::Rollback)
+        }.not_to raise_error
       end
     end
 

--- a/spec/lib/wifi_user/use_cases/sms_response_spec.rb
+++ b/spec/lib/wifi_user/use_cases/sms_response_spec.rb
@@ -68,6 +68,12 @@ describe WifiUser::UseCase::SmsResponse do
       end
     end
 
+    it "does not raise an error" do
+      expect {
+        subject.execute(contact: "447700900003", sms_content: "Help")
+      }.to_not raise_error
+    end
+
     context "For one set of credentials" do
       let(:username) { "AnExampleUsername" }
       let(:password) { "AnExamplePassword" }

--- a/spec/lib/wifi_user/use_cases/sms_response_spec.rb
+++ b/spec/lib/wifi_user/use_cases/sms_response_spec.rb
@@ -91,4 +91,72 @@ describe WifiUser::UseCase::SmsResponse do
       end
     end
   end
+
+  context "With Notifications::Client::BadRequestError" do
+    let(:username) { "hello" }
+    let(:password) { "password" }
+    let(:phone_number) { "+447700900003" }
+    let(:notify_sms_url) { "https://api.notifications.service.gov.uk/v2/notifications/sms" }
+    let(:notify_template_id) { "00000000-7777-8888-9999-000000000000" }
+    let(:notify_sms_request) do
+      {
+        phone_number: phone_number,
+        template_id: notify_template_id,
+        personalisation: {
+          login: username,
+          pass: password,
+        },
+      }
+    end
+
+    context "with ValidationError" do
+      let!(:notify_sms_stub) do
+        stub_request(:post, notify_sms_url).with(body: notify_sms_request)
+          .to_return(status: 400, body: {
+            "errors": [
+              {
+                "error": "ValidationError",
+                "message": "foo",
+              },
+            ],
+            "status_code": 400,
+          }.to_json)
+      end
+
+      before do
+        expect(user_model).to receive(:generate).with(contact: phone_number).and_return(username: username, password: password)
+      end
+
+      it "raises Sequel::Rollback" do
+        expect {
+          subject.execute(contact: "447700900003", sms_content: "")
+        }.to raise_error(Sequel::Rollback)
+      end
+    end
+
+    context "with FooError" do
+      let!(:notify_sms_stub) do
+        stub_request(:post, notify_sms_url).with(body: notify_sms_request)
+          .to_return(status: 400, body: {
+            "errors": [
+              {
+                "error": "FooError",
+                "message": "foo",
+              },
+            ],
+            "status_code": 400,
+          }.to_json)
+      end
+
+      before do
+        expect(user_model).to receive(:generate).with(contact: phone_number).and_return(username: username, password: password)
+      end
+
+      it "raises original error" do
+        expect {
+          subject.execute(contact: "447700900003", sms_content: "")
+        }.to raise_error(Notifications::Client::BadRequestError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
If a text message comes in from an invalid number, a `Notifications::Client::BadRequestError` is raised. There are also other circumstances we haven't seen that could trigger this, such as a text from a landline number.

Catch this error, and if it is due to a `ValidationError` (in the body of the message) log it and rollback. Else throw the original error.

Either way, we're now wrapping the user creation in a transaction, so on either error the user will not be created in the database.