### PR TITLE
Use utf8mb4 when connecting to the database

### DIFF
--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -14,6 +14,7 @@ DB = Sequel.connect(
   database: ENV.fetch("DB_NAME"),
   user: ENV.fetch("DB_USER"),
   password: ENV.fetch("DB_PASS"),
+  encoding: "utf8mb4",
 )
 
 module Common


### PR DESCRIPTION
The Sequel default is utf8, however this can conflict with utf8mb4 which
the database uses. This only surfaces when using multibyte characters such
as emojis. This has caused issues with the smslog, as a surprising number
of people send emojis in their texts.