### PR TITLE
Replace aggregate steps with in_parallel

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -108,7 +108,7 @@ jobs:
   - name: lint & test
     interruptible: true
     plan:
-      - aggregate:
+      - in_parallel:
         - do:
           - get: src
             resource: pull-request
@@ -133,7 +133,7 @@ jobs:
         image: runner
         file: src/ci/tasks/pre-build.yml
 
-      - aggregate:
+      - in_parallel:
         - task: lint
           privileged: true
           image: runner


### PR DESCRIPTION
sed -i '' 's/aggregate/in_parallel/' ci/pipelines/pr.yml

Because of https://github.com/concourse/concourse/releases/tag/v7.0.0 which
we're hoping to roll out soon.