### PR TITLE
[DO NOT MERGE] Adjust template IDs for Chromebook and "recap" messages 

### DIFF
--- a/config/production.yml
+++ b/config/production.yml
@@ -1,13 +1,15 @@
 notify_sms_template_ids:
   credentials: 3a4b1ca8-7b26-4266-8b5f-e05fdbd11879
   help_menu: 2598f762-5c2f-4af8-9309-6ab932047010
-  generic_help: 18859b96-297f-47dd-a579-4e543a83eaa8
+  recap: 299d4f80-59a2-4327-b6c6-0eb5974a242a
   device_help:
+    other: 18859b96-297f-47dd-a579-4e543a83eaa8
     android: 5536eee6-5390-42ec-bdf5-3fe4b15f0127
     blackberry: efa0b4cf-54fd-4d07-ac58-40d633b94e66
     mac: 6ef4ca91-7b88-49eb-9b63-90d39aff3c16
     iphone: ab535538-dc2e-4410-8b40-50fcc852f8bd
     windows: 801d5deb-6480-4fc6-91e1-da9f5f290c0b
+    chromebook: 0e5bbafc-3110-4375-a6e4-4488c503f45a
   active_users_signup_survey: 43134a22-4a00-4546-bf52-965fea3d2beb
   inactive_users_signup_survey: 1550f29b-471c-4e96-be61-97748e07729a
 

--- a/config/staging.yml
+++ b/config/staging.yml
@@ -1,13 +1,15 @@
 notify_sms_template_ids:
   credentials: 24d47eb3-8b02-4eba-aa04-81ffaf4bb1b4
   help_menu: 512deae1-7ec4-4888-8f2d-7be79e5eb379
-  generic_help: 60985003-1682-45a6-8d8d-e121cadbc234
+  recap: 72dbd002-913f-4207-8c74-9a8a576d0dc7
   device_help:
+    other: 60985003-1682-45a6-8d8d-e121cadbc234
     android: ee81124c-2a92-4b63-a7be-258aedb26ed8
     blackberry: 57b362d0-9753-4fd9-ada0-bfd643db8eee
     mac: ec8f83bb-5371-40bf-b777-307a52926fe1
     iphone: 1dc8b2b5-b2e6-4bce-9aae-ee1e9c7cb650
     windows: 3b8f158b-22c8-4226-b84b-3ea5085a46d5
+    chromebook: 1cf2cc2f-fbb3-465b-88b6-521e63cfeab8
   active_users_signup_survey: 3aaaabe1-fa0b-4e41-8033-6dc5e44705eb
   inactive_users_signup_survey: 1479842f-eac5-453d-babf-8dbb2ce97c67
 

--- a/lib/wifi_user/use_case/sms_template_finder.rb
+++ b/lib/wifi_user/use_case/sms_template_finder.rb
@@ -8,7 +8,7 @@ class WifiUser::UseCase::SmsTemplateFinder
       return device_instruction_config.fetch(device_name) if message_content.match?(matcher)
     end
 
-    template_name = "generic_help"
+    template_name = "recap"
     template_name = "credentials" if message_content.match?(/^\s*$/) || message_content.match(/go/i)
     template_name = "help_menu" if message_content.match?(/help/i)
 
@@ -25,11 +25,13 @@ private
 
   def device_name_matchers
     {
+      /0|other/i => "other",
       /1|android|samsung|galaxy|htc|huawei|sony|motorola|lg|nexus/i => "android",
       /2|ios|ipad|iphone|ipod/i => "iphone",
       /3|mac|OSX|apple/i => "mac",
       /4|win|windows/i => "windows",
       /5|blackberry/i => "blackberry",
+      /6|chromebook/i => "chromebook",
     }
   end
 

--- a/spec/lib/wifi_user/use_cases/sms_template_finder_spec.rb
+++ b/spec/lib/wifi_user/use_cases/sms_template_finder_spec.rb
@@ -43,12 +43,12 @@ describe WifiUser::UseCase::SmsTemplateFinder do
     end
   end
 
-  context "Given a message of 4" do
-    let(:windows_template) { "801d5deb-6480-4fc6-91e1-da9f5f290c0b" }
-    it "returns the device template for Windows" do
-      expect(template_for_message("4")).to eq(windows_template)
-      expect(template_for_message(" 4")).to eq(windows_template)
-      expect(template_for_message("hello 4 steve")).to eq(windows_template)
+  context "Given a message of 0" do
+    context "on production" do
+      it "returns the other device template" do
+        expect(template_for_message("0")).to eq("18859b96-297f-47dd-a579-4e543a83eaa8")
+        expect(template_for_message("other")).to eq("18859b96-297f-47dd-a579-4e543a83eaa8")
+      end
     end
   end
 
@@ -59,9 +59,29 @@ describe WifiUser::UseCase::SmsTemplateFinder do
     end
   end
 
+  context "Given a message of 4" do
+    let(:windows_template) { "801d5deb-6480-4fc6-91e1-da9f5f290c0b" }
+    it "returns the device template for Windows" do
+      expect(template_for_message("4")).to eq(windows_template)
+      expect(template_for_message(" 4")).to eq(windows_template)
+      expect(template_for_message("hello 4 steve")).to eq(windows_template)
+    end
+  end
+
+  context "Given a message of 6" do
+    let(:chromebook_template) { "0e5bbafc-3110-4375-a6e4-4488c503f45a" }
+    it "returns the device template for Chromebook" do
+      expect(template_for_message("6")).to eq(chromebook_template)
+      expect(template_for_message(" 6")).to eq(chromebook_template)
+      expect(template_for_message("hello 6 steve")).to eq(chromebook_template)
+      expect(template_for_message("chromebook")).to eq(chromebook_template)
+      expect(template_for_message("hello chromebook steve")).to eq(chromebook_template)
+    end
+  end
+
   context "Given no template could be derived" do
     it "returns the generic help response" do
-      expect(template_for_message("any unmatched content")).to eq("18859b96-297f-47dd-a579-4e543a83eaa8")
+      expect(template_for_message("any unmatched content")).to eq("299d4f80-59a2-4327-b6c6-0eb5974a242a")
     end
   end
 end

--- a/spec/lib/wifi_user/use_cases/sms_template_finder_spec.rb
+++ b/spec/lib/wifi_user/use_cases/sms_template_finder_spec.rb
@@ -80,7 +80,7 @@ describe WifiUser::UseCase::SmsTemplateFinder do
   end
 
   context "Given no template could be derived" do
-    it "returns the generic help response" do
+    it "returns the recap response" do
       expect(template_for_message("any unmatched content")).to eq("299d4f80-59a2-4327-b6c6-0eb5974a242a")
     end
   end


### PR DESCRIPTION
## Note

Pushing this through to production needs to be orchestrated so that the final edit to the Notify template is done at the same time as deploy.

## What

Adds Chromebook (6) and Recap (default) templates.

## Why

Chromebook - adds missing instructions

Recap - previously the default message was the "generic device" instructions... however if you've failed to get to the "Go" point, then these won't help... the new message give useful information regardless of which stage you're stuck at.