### PR TITLE
Remove the limiting code so 100% of users are sent the surveys

### DIFF
--- a/lib/survey/gateway/user_details.rb
+++ b/lib/survey/gateway/user_details.rb
@@ -2,7 +2,7 @@ require "logger"
 
 class Survey::Gateway::UserDetails
   def fetch_active
-    limit WifiUser::Repository::User
+    WifiUser::Repository::User
       .where { created_at > (Date.today - 1).to_time }
       .where { created_at <= Date.today.to_time }
       .where { contact =~ sponsor }
@@ -11,7 +11,7 @@ class Survey::Gateway::UserDetails
   end
 
   def fetch_inactive
-    limit WifiUser::Repository::User
+    WifiUser::Repository::User
       .where { created_at >= (Date.today - 14).to_time }
       .where { created_at < (Date.today - 13).to_time }
       .where { contact =~ sponsor }
@@ -21,17 +21,5 @@ class Survey::Gateway::UserDetails
 
   def mark_as_sent(query)
     query.update(signup_survey_sent_at: Time.now)
-  end
-
-private
-
-  def limit(query)
-    total = query.count
-
-    if total.zero?
-      query
-    else
-      query.limit((total * 0.25).ceil)
-    end
   end
 end

--- a/spec/lib/survey/gateway/user_details_spec.rb
+++ b/spec/lib/survey/gateway/user_details_spec.rb
@@ -36,7 +36,7 @@ describe Survey::Gateway::UserDetails do
           expect(subject.fetch_active).to include(recent_user)
         end
 
-        it "only returns 25% of users" do
+        it "returns 100% of users" do
           FactoryBot.create_list(
             :user_details,
             100,
@@ -45,7 +45,7 @@ describe Survey::Gateway::UserDetails do
             :active,
           )
 
-          expect(subject.fetch_active.count).to eq 26 # 25 + the :recent_user
+          expect(subject.fetch_active.count).to eq 101 # 100 + the :recent_user
         end
       end
     end
@@ -139,7 +139,7 @@ describe Survey::Gateway::UserDetails do
           expect(subject.fetch_inactive).to include(idle_user)
         end
 
-        it "only returns 25% of users" do
+        it "returns 100% of users" do
           FactoryBot.create_list(
             :user_details,
             100,
@@ -148,7 +148,7 @@ describe Survey::Gateway::UserDetails do
             :idle_survey_target,
           )
 
-          expect(subject.fetch_inactive.count).to eq 26 # 25 + the :idle_user
+          expect(subject.fetch_inactive.count).to eq 101 # 100 + the :idle_user
         end
       end
 


### PR DESCRIPTION
### What

Remove the limiting code that only sent the surveys to 25% of users

### Why

Because we want to send the surveys to everyone.


Link to Trello card (if applicable): https://trello.com/c/6Bwk5hRq
