### PR TITLE
Don't record an smslog entry for messages with no number.

### DIFF
--- a/lib/wifi_user/use_case/repetitive_sms_checker.rb
+++ b/lib/wifi_user/use_case/repetitive_sms_checker.rb
@@ -14,6 +14,8 @@ class WifiUser::UseCase::RepetitiveSmsChecker
   def execute(number, message)
     cleanup
 
+    return unless number
+
     @smslog_model.create_log(number, message)
 
     repetitive_number_and_message?(number, message) || repetitive_number?(number)

--- a/spec/lib/wifi_user/use_cases/repetitive_sms_checker_spec.rb
+++ b/spec/lib/wifi_user/use_cases/repetitive_sms_checker_spec.rb
@@ -69,4 +69,11 @@ describe WifiUser::UseCase::RepetitiveSmsChecker do
       expect(DB[:smslog].count).to be(1)
     end
   end
+
+  context "when a received SMS has no number" do
+    it "does not record a log" do
+      subject.execute(nil, "foo")
+      expect(DB[:smslog].count).to be(0)
+    end
+  end
 end


### PR DESCRIPTION
### What

If we get a text message without a number, don't record it in the smslog.

### Why

Sometimes we get text messages with no number. These are typically spam, or someone has entered our number somewhere by accident. These typically appear on phones as coming from a text based source, e.g. `GOOGLE`

As there's no actual number, it tries to insert a record with `nil`. The database is configured with number `NOT NULL` so that errors.

As we'd have no way of replying to these messages anyway, there's no need to record them for purposes of preventing a loop.

Link to Trello card (if applicable): https://trello.com/c/g0u55jLg
