### PR TITLE
Extend GDPR deletion threshold to 2 years

### DIFF
--- a/lib/gdpr/gateway/user_details.rb
+++ b/lib/gdpr/gateway/user_details.rb
@@ -9,8 +9,8 @@ class Gdpr::Gateway::Userdetails
     total = 0
     loop do
       deleted_rows = DB[:userdetails].with_sql_delete("
-        DELETE FROM userdetails WHERE (last_login < DATE_SUB(NOW(), INTERVAL 548 DAY)
-        OR (last_login IS NULL AND created_at < DATE_SUB(NOW(), INTERVAL 548 DAY)))
+        DELETE FROM userdetails WHERE (last_login < DATE_SUB(NOW(), INTERVAL 24 MONTH)
+        OR (last_login IS NULL AND created_at < DATE_SUB(NOW(), INTERVAL 24 MONTH)))
         AND username != 'HEALTH'
         LIMIT #{SESSION_BATCH_SIZE}")
       total += deleted_rows

--- a/spec/lib/gdpr/gateway/user_details_spec.rb
+++ b/spec/lib/gdpr/gateway/user_details_spec.rb
@@ -8,7 +8,7 @@ describe Gdpr::Gateway::Userdetails do
       context "Given no inactive users" do
         before do
           user_details.insert(username: "bob", last_login: Date.today)
-          user_details.insert(username: "sally", last_login: Date.today - 547)
+          user_details.insert(username: "sally", last_login: Date.today - 730)
         end
 
         it "does not delete any users" do
@@ -19,19 +19,20 @@ describe Gdpr::Gateway::Userdetails do
       context "Given one inactive user" do
         before do
           user_details.insert(username: "bob", last_login: Date.today)
-          user_details.insert(username: "george", last_login: Date.today - 549)
+          user_details.insert(username: "sally", created_at: Date.today - 730)
+          user_details.insert(username: "george", last_login: Date.today - 731)
         end
 
         it "does deletes only the old user record" do
           subject.delete_users
-          expect(user_details.all.map { |s| s.fetch(:username) }).to eq(%w[bob])
+          expect(user_details.all.map { |s| s.fetch(:username) }).to eq(%w[bob sally])
         end
       end
 
       context "Given multiple inactive user" do
         before do
-          user_details.insert(username: "bob", last_login: Date.today - 649)
-          user_details.insert(username: "george", last_login: Date.today - 549)
+          user_details.insert(username: "bob", last_login: Date.today - 831)
+          user_details.insert(username: "george", last_login: Date.today - 731)
         end
 
         it "deletes all the inactive users" do
@@ -42,7 +43,7 @@ describe Gdpr::Gateway::Userdetails do
         context "Given a HEALTH user" do
           context "Given the HEALTH user with an inactive last_login" do
             before do
-              user_details.insert(username: "HEALTH", last_login: Date.today - 549)
+              user_details.insert(username: "HEALTH", last_login: Date.today - 731)
             end
 
             it "does not delete the HEALTH user" do
@@ -58,7 +59,7 @@ describe Gdpr::Gateway::Userdetails do
       context "Given no inactive users" do
         before do
           user_details.insert(username: "bob", created_at: Date.today)
-          user_details.insert(username: "sally", created_at: Date.today - 547)
+          user_details.insert(username: "sally", created_at: Date.today - 730)
         end
 
         it "does not delete any user details" do
@@ -69,19 +70,20 @@ describe Gdpr::Gateway::Userdetails do
       context "Given one inactive user" do
         before do
           user_details.insert(username: "bob", created_at: Date.today)
-          user_details.insert(username: "george", created_at: Date.today - 549)
+          user_details.insert(username: "sally", created_at: Date.today - 730)
+          user_details.insert(username: "george", created_at: Date.today - 731)
         end
 
         it "does deletes only the old user record" do
           subject.delete_users
-          expect(user_details.all.map { |s| s.fetch(:username) }).to eq(%w[bob])
+          expect(user_details.all.map { |s| s.fetch(:username) }).to eq(%w[bob sally])
         end
       end
 
       context "Given multiple inactive user" do
         before do
-          user_details.insert(username: "bob", created_at: Date.today - 649)
-          user_details.insert(username: "george", created_at: Date.today - 549)
+          user_details.insert(username: "bob", created_at: Date.today - 831)
+          user_details.insert(username: "george", created_at: Date.today - 731)
         end
 
         it "deletes all the inactive users" do


### PR DESCRIPTION
### What
Extend GDPR deletion threshold to 2 years

### Why
We're reaching 18 months and there's still people not back in the office
