### PR TITLE
Add Github workflow to lint and test our code

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,34 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.3
+      - name: Install dependencies
+        run: bundle install
+      - name: Run lint
+        run: make lint
+
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.3
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: make test


### PR DESCRIPTION
### What
Add Github workflow to lint and test our code.

### Why
We are migrating our PR pipelines away from Concourse into Github
Actions. 

Link to Trello card (if applicable): https://trello.com/c/yTuD851K/1959-learn-about-github-actions-as-a-replacement-for-concourse


