### PR TITLE
let's set a sensible name rather than the filename

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,3 +1,4 @@
+name: user-signup-api lint and test
 on:
   push:
     branches:


### PR DESCRIPTION
### What
Add a 'name' for our lint & test pipeline

### Why
The default is purely the filename and this does not describe the function of this workflow. We may add further workflows, so let's label this sensibly.

Link to Trello card (if applicable): 
