### PR TITLE
Handle parse errors when parsing email addresses for user signup

### DIFF
--- a/lib/wifi_user/use_case/email_signup.rb
+++ b/lib/wifi_user/use_case/email_signup.rb
@@ -16,6 +16,8 @@ class WifiUser::UseCase::EmailSignup
     else
       logger.info("Unsuccessful email signup attempt: #{email_address}")
     end
+  rescue Mail::Field::ParseError => e
+    logger.warn("unable to parse |#{contact}|: #{e}")
   end
 
 private

--- a/spec/lib/wifi_user/use_cases/email_signup_spec.rb
+++ b/spec/lib/wifi_user/use_cases/email_signup_spec.rb
@@ -105,4 +105,12 @@ describe WifiUser::UseCase::EmailSignup do
       end
     end
   end
+
+  describe "Using a unparsable contact" do
+    it "logs the error" do
+      expect(subject.send(:logger)).to receive(:warn)
+
+      subject.execute(contact: "Ryan <ryan@example.com")
+    end
+  end
 end


### PR DESCRIPTION
### What
Handle parse errors when parsing email addresses for user signup

### Why
So that these are just logged, rather than making it to Sentry.


Link to Trello card: https://trello.com/c/lzTo5ku0/1998-dont-alert-sentry-on-malformed-email-address