### PR TITLE
Run the tests with bundle exec

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,10 +12,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-      - name: Install dependencies
-        run: bundle install
       - name: Run lint
         run: make lint
 
@@ -23,9 +19,5 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-      - name: Install dependencies
-        run: bundle install
       - name: Run tests
         run: make test

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby File.read(".ruby-version").chomp
 gem "aws-sdk-s3", "~> 1"
 gem "mail", "~> 2.7"
 gem "mysql2"
+gem "net-smtp"
 gem "nokogiri", "~> 1.13"
 gem "notifications-ruby-client", "~> 5.3.0"
 gem "puma"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
+    digest (3.1.0)
     docile (1.4.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
@@ -58,6 +59,7 @@ GEM
     hashdiff (1.0.1)
     i18n (1.9.1)
       concurrent-ruby (~> 1.0)
+    io-wait (0.2.1)
     jmespath (1.6.0)
     jwt (2.3.0)
     listen (3.7.0)
@@ -75,6 +77,13 @@ GEM
       ruby2_keywords (~> 0.0.1)
     mysql2 (0.5.3)
     nenv (0.3.0)
+    net-protocol (0.1.2)
+      io-wait
+      timeout
+    net-smtp (0.3.1)
+      digest
+      net-protocol
+      timeout
     nio4r (2.5.8)
     nokogiri (1.13.3)
       mini_portile2 (~> 2.8.0)
@@ -168,6 +177,7 @@ GEM
     thor (1.0.1)
     tilt (2.0.10)
     timecop (0.9.4)
+    timeout (0.2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
@@ -186,6 +196,7 @@ DEPENDENCIES
   guard-rspec
   mail (~> 2.7)
   mysql2
+  net-smtp
   nokogiri (~> 1.13)
   notifications-ruby-client (~> 5.3.0)
   puma
@@ -203,7 +214,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 3.0.3p157
+   ruby 3.1.1p18
 
 BUNDLED WITH
    2.2.32

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lint:
 
 test:
 	$(MAKE) serve
-	$(DOCKER_COMPOSE) run --rm app rspec
+	$(DOCKER_COMPOSE) run --rm app bundle exec rspec
 	$(MAKE) stop
 
 shell: serve


### PR DESCRIPTION
### What
Run the tests with bundle exec, also remove redundant bits from the GitHub Actions workflow. Plus install the net-smtp gem.

### Why
This makes the tests more rigorous and GitHub Actions run faster.


Link to Trello card: https://trello.com/c/4volBC42/2069-upgrade-ruby-to-311