### PR TITLE
Reply to rejected email signups

### DIFF
--- a/config/production.yml
+++ b/config/production.yml
@@ -15,6 +15,7 @@ notify_sms_template_ids:
 
 notify_email_template_ids:
   self_signup_credentials: f18708c0-e857-4f62-b5f3-8f0c75fc2fdb
+  rejected_email_address: 66a2be00-8398-43bc-b952-96c97420f6cf
   sponsored_credentials: fd536b81-bdd7-4b55-98aa-720173718642
   sponsor_confirmation:
     plural: 58e8ef4a-ca6b-40cd-81df-ec9c781fed56

--- a/config/staging.yml
+++ b/config/staging.yml
@@ -14,6 +14,7 @@ notify_sms_template_ids:
 
 notify_email_template_ids:
   self_signup_credentials: 96d1f5ac-2ebe-41a7-878f-9a569e0bb55c
+  rejected_email_address:  dabb9566-ae35-4ada-a9c5-2dd0db099539
   sponsored_credentials: 4f6bae31-5add-43a9-b0e3-7db43452676e
   sponsor_confirmation:
     plural: 856a5726-1099-4236-b67c-23b654e9edbf

--- a/config/test.yml
+++ b/config/test.yml
@@ -12,6 +12,7 @@ notify_sms_template_ids:
 
 notify_email_template_ids:
   self_signup_credentials: iii
+  rejected_email_address: test-rejected-email-address-template-id
   sponsored_credentials: jjj
   sponsor_confirmation:
     plural: kkk

--- a/lib/wifi_user/use_case/email_signup.rb
+++ b/lib/wifi_user/use_case/email_signup.rb
@@ -15,6 +15,7 @@ class WifiUser::UseCase::EmailSignup
       send_signup_instructions(email_address)
     else
       logger.info("Unsuccessful email signup attempt: #{email_address}")
+      send_rejected_email_address_email(email_address)
     end
   rescue Mail::Field::ParseError => e
     logger.warn("unable to parse |#{contact}|: #{e}")
@@ -35,8 +36,22 @@ private
     )
   end
 
+  def send_rejected_email_address_email(email_address)
+    client = Notifications::Client.new(ENV.fetch("NOTIFY_API_KEY"))
+
+    client.send_email(
+      email_address:,
+      template_id: rejected_email_address_template_id,
+      email_reply_to_id: do_not_reply_email_address_id,
+    )
+  end
+
   def credentials_template_id
     YAML.load_file("config/#{ENV['RACK_ENV']}.yml").fetch("notify_email_template_ids").fetch("self_signup_credentials")
+  end
+
+  def rejected_email_address_template_id
+    YAML.load_file("config/#{ENV['RACK_ENV']}.yml").fetch("notify_email_template_ids").fetch("rejected_email_address")
   end
 
   def do_not_reply_email_address_id

--- a/spec/lib/wifi_user/use_cases/email_signup_spec.rb
+++ b/spec/lib/wifi_user/use_cases/email_signup_spec.rb
@@ -89,9 +89,18 @@ describe WifiUser::UseCase::EmailSignup do
 
       context "given an email address with a non-gov domain" do
         let(:whitelist_checker) { double(execute: { success: false }) }
-        let(:created_contact) { "irrelevant@somewhere.uk" }
+        let(:created_contact) { "ryan@example.com" }
         let(:username) { "irrelevant" }
         let(:password) { "irrelephant" }
+        let(:notify_template_id) { "dabb9566-ae35-4ada-a9c5-2dd0db099539" }
+
+        let(:notify_email_request) do
+          {
+            email_address: created_contact,
+            template_id: notify_template_id,
+            email_reply_to_id: do_not_reply_id,
+          }
+        end
 
         before { subject.execute(contact: "Ryan <ryan@example.com>") }
 
@@ -99,8 +108,8 @@ describe WifiUser::UseCase::EmailSignup do
           expect(user_model).not_to receive(:generate)
         end
 
-        it "does not send an email to Notify" do
-          expect(notify_email_stub).to_not have_been_requested
+        it "sends an email to Notify" do
+          expect(notify_email_stub).to have_been_requested.times(1)
         end
       end
     end


### PR DESCRIPTION
### What
Reply to rejected email signups

### Why
The intent here is to let people know they won't get credentials when
they try to signup with an unrecognised email address, and direct them
to either signup via text message or have someone sponsor them.



Link to Trello card: https://trello.com/c/84mUFy3f/2266-let-unrecognised-email-domains-know-they-wont-get-credentials