### PR TITLE
Omit hash value where possible

### DIFF
--- a/lib/wifi_user/repository/smslog.rb
+++ b/lib/wifi_user/repository/smslog.rb
@@ -1,6 +1,6 @@
 class WifiUser::Repository::Smslog < Sequel::Model(:smslog)
   def create_log(number, message)
-    self.class.insert number: number, message: message
+    self.class.insert number:, message:
   end
 
   def get_matching(number:, within_minutes:, message: nil)

--- a/spec/features/sms_spec.rb
+++ b/spec/features/sms_spec.rb
@@ -13,7 +13,7 @@ describe App do
       {
         source_number: from_phone_number,
         destination_number: to_phone_number,
-        message: message,
+        message:,
       }.to_json
     end
 

--- a/spec/lib/wifi_user/use_cases/sms_response_spec.rb
+++ b/spec/lib/wifi_user/use_cases/sms_response_spec.rb
@@ -31,7 +31,7 @@ describe WifiUser::UseCase::SmsResponse do
     let(:notify_template_id) { "00000000-7777-8888-9999-000000000000" }
     let(:notify_sms_request) do
       {
-        phone_number: phone_number,
+        phone_number:,
         template_id: notify_template_id,
         personalisation: {
           login: username,
@@ -106,7 +106,7 @@ describe WifiUser::UseCase::SmsResponse do
     let(:notify_template_id) { "00000000-7777-8888-9999-000000000000" }
     let(:notify_sms_request) do
       {
-        phone_number: phone_number,
+        phone_number:,
         template_id: notify_template_id,
         personalisation: {
           login: username,

--- a/spec/lib/wifi_user/use_cases/sponsor_users_spec.rb
+++ b/spec/lib/wifi_user/use_cases/sponsor_users_spec.rb
@@ -273,7 +273,7 @@ describe WifiUser::UseCase::SponsorUsers do
 
   def a_signup_sms(phone_number:)
     {
-      phone_number: phone_number,
+      phone_number:,
       template_id: "3a4b1ca8-7b26-4266-8b5f-e05fdbd11879",
       template_parameters: {
         login: username,


### PR DESCRIPTION
### What
Omit hash value where possible
### Why
This so that the linter still passes when we upgrade