### PR TITLE
Make Container Name Consistent

### DIFF
--- a/ci/tasks/deploy.yml
+++ b/ci/tasks/deploy.yml
@@ -11,7 +11,7 @@ params:
   SERVICE_NAME: "user-signup-api-service"
   CLUSTER_NAME: "api-cluster"
   TASK_NAME: "user-signup-api"
-  CONTAINER_NAME: "user-signup"
+  CONTAINER_NAME: "user-signup-api"
 
 inputs:
   - name: src


### PR DESCRIPTION
### What
Make container name consistent with the name we use for the ECS service,
cluster and task definition. In our ECS task definitions we currently declare a container name that is different from the app, task and cluster name:
[govwifi-terraform/user-signup-api-cluster.tf at 13c45e4791ba82dfaba89cf68847eb2d720c4825 · alphagov/govwifi-terraform](https://github.com/alphagov/govwifi-terraform/blob/13c45e4791ba82dfaba89cf68847eb2d720c4825/govwifi-api/user-signup-api-cluster.tf#L201)

The name used is user-signup but elsewhere we use user-signup-**api** to refer to related resources like the ECS service. This should be consistent - user-signup-api should be used everywhere, and references to user-signup` should be deleted.

### Why
Using different values for the container name, service name and cluster name is confusing and makes writing the pipeline code more complicated. 

**This is related to PR:**
https://github.com/alphagov/govwifi-terraform/pull/690

Link to Trello card: https://trello.com/c/vf9rqnRW/1501-make-user-signup-container-name-references-in-terraform-deploy-process-consistent
