### PR TITLE
Introduce an AWS Codebuild Task

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,8 @@ COPY . .
 
 ENV GOVNOTIFY_BEARER_TOKEN ''
 
+RUN   set -x
+
 CMD ["bundle", "exec", "rackup", "-o", "0.0.0.0", "-p", "8080"]
+
+RUN set +x

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # GovWifi User Signup API
 
+
 This handles incoming sign-up texts and e-mails.
 
 The private GovWifi [build repository][build-repo] contains instructions on how to build GovWifi end-to-end - the sites, services and infrastructure.

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,29 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - aws --version
+      - echo "AWS_REGION is $AWS_REGION "
+      - REPOSITORY_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/govwifi/$STAGE/user-signup-api
+      - echo "REPOSITORY_URI is $REPOSITORY_URI"
+      - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - IMAGE_TAG="latest"
+      - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
+      - aws s3 cp s3://$WORDLIST_BUCKET_NAME/wordlist-short /tmp/wordlist
+  build:
+    commands:
+      - echo Build started on `date`
+      - BUNDLE_INSTALL_CMD="set -x ; bundle install --jobs 20 --retry 5"
+      - echo Building the Docker image...
+      - docker build --build-arg BUNDLE_INSTALL_CMD='bundle install --jobs 20 --retry 5' -t $REPOSITORY_URI:$IMAGE_TAG .
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker images...
+      - docker push $REPOSITORY_URI:$IMAGE_TAG
+      - echo Writing image definitions file...
+      - printf '[{"name":"user-signup","imageUri":"%s"}]' $REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
+      - set +x

--- a/cd/yml/build-convert-imagedetail.yml
+++ b/cd/yml/build-convert-imagedetail.yml
@@ -1,0 +1,53 @@
+projects:
+  - name: convert-imagedetail
+    arn: arn:aws:codebuild:eu-west-2:991518808406:project/convert-imagedetail
+    source:
+      type: NO_SOURCE
+      gitCloneDepth: 1
+      buildspec: |-
+        version: 0.2
+        phases:
+            build:
+                commands:
+                    - ContainerName="user-signup"
+                    - ImageURI=$(cat imageDetail.json | jq -r '.ImageURI')
+                    - printf '[{"name":"CONTAINER_NAME","imageUri":"IMAGE_URI"}]' > imagedefinitions.json
+                    - sed -i -e "s|CONTAINER_NAME|$ContainerName|g" imagedefinitions.json
+                    - sed -i -e "s|IMAGE_URI|$ImageURI|g" imagedefinitions.json
+                    - cat imagedefinitions.json
+
+        artifacts:
+            files:
+                - imagedefinitions.json
+      insecureSsl: false
+    secondarySources: []
+    secondarySourceVersions: []
+    artifacts:
+      type: NO_ARTIFACTS
+    secondaryArtifacts: []
+    cache:
+      type: NO_CACHE
+    environment:
+      type: LINUX_CONTAINER
+      image: aws/codebuild/standard:5.0
+      computeType: BUILD_GENERAL1_SMALL
+      environmentVariables: []
+      privilegedMode: true
+      imagePullCredentialsType: CODEBUILD
+    serviceRole: arn:aws:iam::991518808406:role/service-role/codebuild-convert-imagedetail-service-role
+    timeoutInMinutes: 60
+    queuedTimeoutInMinutes: 480
+    encryptionKey: arn:aws:kms:eu-west-2:991518808406:alias/aws/s3
+    tags: []
+    created: "2022-05-11T17:24:44.863000+01:00"
+    lastModified: "2022-05-11T17:38:42.036000+01:00"
+    badge:
+      badgeEnabled: false
+    logsConfig:
+      cloudWatchLogs:
+        status: ENABLED
+      s3Logs:
+        status: DISABLED
+        encryptionDisabled: false
+    projectVisibility: PRIVATE
+projectsNotFound: []

--- a/cd/yml/build-user-signup-api.yml
+++ b/cd/yml/build-user-signup-api.yml
@@ -1,0 +1,72 @@
+projects:
+  - name: David
+    arn: arn:aws:codebuild:eu-west-2:991518808406:project/David
+    source:
+      type: GITHUB
+      location: https://github.com/alphagov/govwifi-user-signup-api.git
+      gitCloneDepth: 1
+      gitSubmodulesConfig:
+        fetchSubmodules: false
+      buildspec: buildspec-build.yml
+      reportBuildStatus: false
+      insecureSsl: false
+    secondarySources: []
+    sourceVersion: codebuild-test
+    secondarySourceVersions: []
+    artifacts:
+      type: S3
+      location: codepipeline-eu-west-2-763178963536
+      path: David/source-art
+      namespaceType: NONE
+      name: David
+      packaging: ZIP
+      overrideArtifactName: false
+      encryptionDisabled: false
+    secondaryArtifacts: []
+    cache:
+      type: NO_CACHE
+    environment:
+      type: LINUX_CONTAINER
+      image: aws/codebuild/standard:5.0
+      computeType: BUILD_GENERAL1_SMALL
+      environmentVariables:
+        - name: AWS_ACCOUNT_ID
+          value: "991518808406"
+          type: PLAINTEXT
+        - name: AWS_REGION
+          value: eu-west-2
+          type: PLAINTEXT
+        - name: STAGE
+          value: staging
+          type: PLAINTEXT
+        - name: DOCKER_HUB_AUTHTOKEN_ENV
+          value: /govwifi-cd/pipelines/main/docker_hub_authtoken
+          type: PARAMETER_STORE
+        - name: DOCKER_HUB_USERNAME_ENV
+          value: /govwifi-cd/pipelines/main/docker_hub_username
+          type: PARAMETER_STORE
+        - name: WORDLIST_BUCKET_NAME
+          value: wordlist-20211214154822339700000001
+          type: PLAINTEXT
+      privilegedMode: true
+      imagePullCredentialsType: CODEBUILD
+    serviceRole: arn:aws:iam::991518808406:role/service-role/codebuild-David-service-role
+    timeoutInMinutes: 60
+    queuedTimeoutInMinutes: 480
+    encryptionKey: arn:aws:kms:eu-west-2:991518808406:alias/aws/s3
+    tags: []
+    created: "2022-05-10T15:27:15.965000+01:00"
+    lastModified: "2022-05-13T14:31:47.451000+01:00"
+    badge:
+      badgeEnabled: false
+    logsConfig:
+      cloudWatchLogs:
+        status: ENABLED
+        groupName: CodeBuild
+      s3Logs:
+        status: ENABLED
+        location: codepipeline-eu-west-2-763178963536/logs
+        encryptionDisabled: false
+    fileSystemLocations: []
+    projectVisibility: PRIVATE
+projectsNotFound: []

--- a/cd/yml/pipeline-user-signup-api.yml
+++ b/cd/yml/pipeline-user-signup-api.yml
@@ -1,0 +1,62 @@
+pipeline:
+  name: David
+  roleArn: arn:aws:iam::991518808406:role/service-role/AWSCodePipelineServiceRole-eu-west-2-David
+  artifactStore:
+    type: S3
+    location: codepipeline-eu-west-2-763178963536
+  stages:
+    - name: Source
+      actions:
+        - name: Source
+          actionTypeId:
+            category: Source
+            owner: AWS
+            provider: ECR
+            version: "1"
+          runOrder: 1
+          configuration:
+            ImageTag: staging
+            RepositoryName: govwifi/user-signup-api
+          outputArtifacts:
+            - name: source-artifact-david
+          inputArtifacts: []
+          region: eu-west-2
+          namespace: SourceVariables
+    - name: Convert-Imagedetail-file
+      actions:
+        - name: Convert-Imagedetail
+          actionTypeId:
+            category: Build
+            owner: AWS
+            provider: CodeBuild
+            version: "1"
+          runOrder: 1
+          configuration:
+            ProjectName: convert-imagedetail
+          outputArtifacts:
+            - name: amended-imagedetail
+          inputArtifacts:
+            - name: source-artifact-david
+          region: eu-west-2
+    - name: Deploy
+      actions:
+        - name: Deploy
+          actionTypeId:
+            category: Deploy
+            owner: AWS
+            provider: ECS
+            version: "1"
+          runOrder: 1
+          configuration:
+            ClusterName: staging-api-cluster
+            ServiceName: user-signup-api-service-staging
+          outputArtifacts: []
+          inputArtifacts:
+            - name: amended-imagedetail
+          region: eu-west-2
+          namespace: DeployVariables
+  version: 14
+metadata:
+  pipelineArn: arn:aws:codepipeline:eu-west-2:991518808406:David
+  created: "2022-05-10T15:02:44.997000+01:00"
+  updated: "2022-05-12T15:07:27.583000+01:00"

--- a/cd/yml/tools-build-step-one.yml
+++ b/cd/yml/tools-build-step-one.yml
@@ -1,0 +1,71 @@
+projects:
+- arn: arn:aws:codebuild:eu-west-2:564433011836:project/govwifi-codebuild-user-signup-api-step-one
+  artifacts:
+    overrideArtifactName: false
+    type: NO_ARTIFACTS
+  badge:
+    badgeEnabled: false
+  cache:
+    location: govwifi-codepipeline-bucket
+    type: S3
+  created: '2022-04-14T17:01:45.979000+01:00'
+  description: Test codebuild project for the user-signup-api
+  encryptionKey: arn:aws:kms:eu-west-2:564433011836:alias/aws/s3
+  environment:
+    computeType: BUILD_GENERAL1_SMALL
+    environmentVariables:
+    - name: AWS_ACCOUNT_ID
+      type: PLAINTEXT
+      value: '991518808406'
+    - name: AWS_REGION
+      type: PLAINTEXT
+      value: eu-west-2
+    - name: STAGE
+      type: PLAINTEXT
+      value: staging
+    - name: DOCKER_HUB_AUTHTOKEN_ENV
+      type: PARAMETER_STORE
+      value: /govwifi-cd/pipelines/main/docker_hub_authtoken
+    - name: DOCKER_HUB_USERNAME_ENV
+      type: PARAMETER_STORE
+      value: /govwifi-cd/pipelines/main/docker_hub_username
+    image: aws/codebuild/standard:5.0
+    imagePullCredentialsType: CODEBUILD
+    privilegedMode: true
+    type: LINUX_CONTAINER
+  lastModified: '2022-04-14T17:01:46.531000+01:00'
+  logsConfig:
+    cloudWatchLogs:
+      groupName: govwifi-codepipeline-log-group
+      status: ENABLED
+      streamName: govwifi-codepipeline-log-stream
+    s3Logs:
+      encryptionDisabled: false
+      location: govwifi-codepipeline-bucket/build-log
+      status: ENABLED
+  name: govwifi-codebuild-user-signup-api-step-one
+  projectVisibility: PRIVATE
+  queuedTimeoutInMinutes: 480
+  serviceRole: arn:aws:iam::564433011836:role/govwifi-codebuild-role
+  source:
+    buildspec: buildspec-build.yml
+    gitCloneDepth: 1
+    insecureSsl: false
+    location: https://github.com/alphagov/govwifi-user-signup-api.git
+    reportBuildStatus: false
+    type: GITHUB
+  sourceVersion: codebuild-test
+  tags: []
+  timeoutInMinutes: 5
+  webhook:
+    buildType: BUILD
+    filterGroups:
+    - - excludeMatchedPattern: false
+        pattern: PUSH
+        type: EVENT
+      - excludeMatchedPattern: false
+        pattern: ^refs/heads/codebuild-test$
+        type: HEAD_REF
+    payloadUrl: https://codebuild.eu-west-2.amazonaws.com/webhooks?t=eyJlbmNyeXB0ZWREYXRhIjoiWkZHV1BoMzU2L0NBaTc5ekdaV29wTlFIbGoybkpLVkdXM1kxY2ZuL2p0UFVYRWx4WHExU1VVQ3FUODNPaUNBUUpmMERqM1FydlhwckhSUlg0Wmd2U05FPSIsIml2UGFyYW1ldGVyU3BlYyI6InVoYXpRZkx4Ti9XbU05UU8iLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&v=1
+    url: https://api.github.com/repos/alphagov/govwifi-user-signup-api/hooks/353298123
+projectsNotFound: []

--- a/cd/yml/tools-pipeline-user-signup-api.yml
+++ b/cd/yml/tools-pipeline-user-signup-api.yml
@@ -1,0 +1,42 @@
+metadata:
+  created: '2022-04-14T16:58:33.875000+01:00'
+  pipelineArn: arn:aws:codepipeline:eu-west-2:564433011836:govwifi-deploy-pipeline-user-signup-api
+  updated: '2022-04-14T16:58:33.875000+01:00'
+pipeline:
+  artifactStore:
+    location: govwifi-codepipeline-bucket
+    type: S3
+  name: govwifi-deploy-pipeline-user-signup-api
+  roleArn: arn:aws:iam::564433011836:role/govwifi-codepipeline-role
+  stages:
+  - actions:
+    - actionTypeId:
+        category: Source
+        owner: AWS
+        provider: ECR
+        version: '1'
+      configuration:
+        ImageTag: staging
+        RepositoryName: govwifi/user-signup-api
+      inputArtifacts: []
+      name: NewECRImagDetectedFor-user-signup-api
+      outputArtifacts:
+      - name: SourceArtifact
+      runOrder: 1
+    name: Source
+  - actions:
+    - actionTypeId:
+        category: Deploy
+        owner: AWS
+        provider: CodeDeploy
+        version: '1'
+      configuration:
+        ApplicationName: my-application
+        DeploymentGroupName: my-deployment-group
+      inputArtifacts:
+      - name: SourceArtifact
+      name: Deploy
+      outputArtifacts: []
+      runOrder: 1
+    name: Deploy
+  version: 1

--- a/ci/tasks/scripts/deploy-tools/aws-helpers.sh
+++ b/ci/tasks/scripts/deploy-tools/aws-helpers.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+set -v -e -u -o pipefail
+
+function stage_name() {
+  local deploy_stage="${STAGE}"
+  [[ "${deploy_stage}" == 'production' ]] && deploy_stage='wifi'
+
+  echo "$deploy_stage"
+}
+
+function get_network_config() {
+  local cluster_name="${1}"
+  local service_name="${2}"
+
+  aws ecs describe-services \
+        --cluster "${cluster_name}" \
+        --service "${service_name}" \
+        --output json \
+        --query 'services[0].networkConfiguration'
+}
+
+function get_launch_type() {
+  local cluster_name="${1}"
+  local service_name="${2}"
+
+  aws ecs describe-services \
+        --cluster "${cluster_name}" \
+        --service "${service_name}" \
+        --output text \
+        --query 'services[0].launchType'
+}
+
+function get_platform_version() {
+  local cluster_name="${1}"
+  local service_name="${2}"
+
+  aws ecs describe-services \
+        --cluster "${cluster_name}" \
+        --service "${service_name}" \
+        --output text \
+        --query 'services[0].platformVersion'
+}
+
+function run_task_with_command() {
+  local cluster_name="${1}"
+  local service_name="${2}"
+  local task_definition="${3}"
+  local docker_service_name="${4}"
+  local command="${5}"
+  local network_config launch_type
+
+  network_config="$(get_network_config "${cluster_name}" "${service_name}")"
+  launch_type="$(get_launch_type "${cluster_name}" "${service_name}")"
+  platform_version="$(get_platform_version "${cluster_name}" "${service_name}")"
+
+  aws ecs run-task \
+        --cluster "${cluster_name}" \
+        --task-definition "${task_definition}" \
+        --launch-type "${launch_type}" \
+        --platform-version "${platform_version}" \
+        --network-configuration "${network_config}" \
+        --count 1 \
+        --override "$(override_command_structure "${docker_service_name}" "${command}")"
+}
+
+function form_command_override() {
+  local override_command="${1}"
+  override_command="${override_command}" python -c \
+    'import os,json,shlex; print(json.dumps(shlex.split(os.environ["override_command"])))'
+}
+
+function override_command_structure() {
+  local docker_service="${1}"
+  local command="${2}"
+
+  cat <<EOF
+  {
+    "containerOverrides": [
+      {
+        "name": "${docker_service}",
+        "command": $(form_command_override "${command}")
+      }
+    ]
+  }
+EOF
+}
+
+function ecs_deploy_region() {
+  local cluster_name="${1}"
+  local service_name="${2}"
+  local region="${3}"
+
+  aws ecs update-service \
+        --cluster "${cluster_name}" \
+        --service "${service_name}" \
+        --region "${region}" \
+        --force-new-deployment
+}
+
+function ecs_deploy() {
+  local cluster_name="${1}"
+  local service_name="${2}"
+
+  aws ecs update-service \
+        --cluster "${cluster_name}" \
+        --service "${service_name}" \
+        --force-new-deployment
+}

--- a/ci/tasks/scripts/deploy.sh
+++ b/ci/tasks/scripts/deploy.sh
@@ -2,7 +2,7 @@
 
 set -v -e -u -o pipefail
 
-source deploy-tools/aws-helpers.sh
+source ci/tasks/scripts/deploy-tools/aws-helpers.sh
 
 function deploy() {
   local cluster_name service_name deploy_stage

--- a/ci/tasks/scripts/migrate.sh
+++ b/ci/tasks/scripts/migrate.sh
@@ -2,7 +2,7 @@
 
 set -v -e -u -o pipefail
 
-source deploy-tools/aws-helpers.sh
+source ci/tasks/scripts/deploy-tools/aws-helpers.sh
 
 function migrate() {
   local migration_command="bundle exec rake db:migrate"
@@ -13,6 +13,11 @@ function migrate() {
   cluster_name="${deploy_stage}-${CLUSTER_NAME}"
   service_name="${SERVICE_NAME}-${deploy_stage}"
   task_definition="${TASK_NAME}-task-${deploy_stage}"
+
+  echo "deploy_stage: " $deploy_stage
+  echo "cluster_name: " $cluster_name
+  echo "service_name: " $service_name
+  echo "task_definition: " $task_definition
 
   run_task_with_command \
     "${cluster_name}" \


### PR DESCRIPTION
### What
Introduce an AWS Codebuild task permitting us to migrate from concourse to AWS Developer Tools

### Why
We need to migrate away from Concourse due to strategic decision to use managed services.


### Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-253