### PR TITLE
GW-647 Send reminder of credentials to Sponsored Users when they email 'sign…

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -38,9 +38,14 @@ class App < Sinatra::Base
       ),
     )
 
+    check_user_is_sponsee = WifiUser::UseCase::CheckUserIsSponsee.new(
+      allowlist_checker:,
+    )
+
     email_signup_handler = ::WifiUser::UseCase::EmailSignup.new(
       user_model: WifiUser::Repository::User.new,
       allowlist_checker:,
+      check_user_is_sponsee:,
       logger:,
     )
 

--- a/app.rb
+++ b/app.rb
@@ -38,14 +38,12 @@ class App < Sinatra::Base
       ),
     )
 
-    check_user_is_sponsee = WifiUser::UseCase::CheckUserIsSponsee.new(
-      allowlist_checker:,
-    )
+    sponsee_is_user_checker = WifiUser::UseCase::CheckUserIsSponsee.new
 
     email_signup_handler = ::WifiUser::UseCase::EmailSignup.new(
       user_model: WifiUser::Repository::User.new,
       allowlist_checker:,
-      check_user_is_sponsee:,
+      sponsee_is_user_checker:,
       logger:,
     )
 

--- a/lib/wifi_user/use_case/check_user_is_sponsee.rb
+++ b/lib/wifi_user/use_case/check_user_is_sponsee.rb
@@ -1,20 +1,7 @@
 class WifiUser::UseCase::CheckUserIsSponsee
-  def initialize(allowlist_checker:)
-    @allowlist_checker = allowlist_checker
-  end
-
   def execute(contact)
-    sponsee = DB[:userdetails].where(contact:)&.first
+    sponsee = WifiUser::Repository::User.find(contact:)
 
-    return false unless sponsee
-    return false unless sponsee[:sponsor]
-
-    sponsor_email = sponsee[:sponsor]
-
-    allowlist_checker.execute(sponsor_email)[:success]
+    sponsee.present? && sponsee[:sponsor] != contact
   end
-
-private
-
-  attr_reader :allowlist_checker
 end

--- a/lib/wifi_user/use_case/check_user_is_sponsee.rb
+++ b/lib/wifi_user/use_case/check_user_is_sponsee.rb
@@ -1,0 +1,20 @@
+class WifiUser::UseCase::CheckUserIsSponsee
+  def initialize(allowlist_checker:)
+    @allowlist_checker = allowlist_checker
+  end
+
+  def execute(contact)
+    sponsee = DB[:userdetails].where(contact:)&.first
+
+    return false unless sponsee
+    return false unless sponsee[:sponsor]
+
+    sponsor_email = sponsee[:sponsor]
+
+    allowlist_checker.execute(sponsor_email)[:success]
+  end
+
+private
+
+  attr_reader :allowlist_checker
+end

--- a/lib/wifi_user/use_case/email_signup.rb
+++ b/lib/wifi_user/use_case/email_signup.rb
@@ -2,18 +2,20 @@ require "mail"
 require "notifications/client"
 
 class WifiUser::UseCase::EmailSignup
-  def initialize(user_model:, allowlist_checker:, check_user_is_sponsee:, logger: Logger.new($stdout))
+  def initialize(user_model:, allowlist_checker:, sponsee_is_user_checker:, logger: Logger.new($stdout))
     @user_model = user_model
     @allowlist_checker = allowlist_checker
-    @check_user_is_sponsee = check_user_is_sponsee
+    @sponsee_is_user_checker = sponsee_is_user_checker
     @logger = logger
   end
 
   def execute(contact:)
     email_address = Mail::Address.new(contact).address
 
-    if allowlist_checker.execute(email_address)[:success] || check_user_is_sponsee.execute(email_address)
+    if allowlist_checker.execute(email_address)[:success]
       send_signup_instructions(email_address)
+    elsif sponsee_is_user_checker.execute(email_address)
+      send_sponsor_signup_instructions(email_address)
     else
       logger.info("Unsuccessful email signup attempt: #{email_address}")
       send_rejected_email_address_email(email_address)
@@ -24,7 +26,7 @@ class WifiUser::UseCase::EmailSignup
 
 private
 
-  attr_accessor :user_model, :allowlist_checker, :logger, :check_user_is_sponsee
+  attr_accessor :user_model, :allowlist_checker, :logger, :sponsee_is_user_checker
 
   def send_signup_instructions(email_address)
     client = Notifications::Client.new(ENV.fetch("NOTIFY_API_KEY"))
@@ -47,6 +49,21 @@ private
     )
   end
 
+  def send_sponsor_signup_instructions(email_address)
+    sponsee = WifiUser::Repository::User.find(contact: email_address)
+    return unless sponsee.present?
+
+    login_details = user_model.generate(contact: email_address)
+    client = Notifications::Client.new(ENV.fetch("NOTIFY_API_KEY"))
+
+    client.send_email(
+      email_address:,
+      template_id: sponsored_credentials_template,
+      personalisation: login_details.merge(sponsor: sponsee.sponsor),
+      email_reply_to_id: do_not_reply_email_address_id,
+    )
+  end
+
   def credentials_template_id
     YAML.load_file("config/#{ENV['RACK_ENV']}.yml").fetch("notify_email_template_ids").fetch("self_signup_credentials")
   end
@@ -57,5 +74,9 @@ private
 
   def do_not_reply_email_address_id
     YAML.load_file("config/#{ENV['RACK_ENV']}.yml").fetch("do_not_reply_email_id")
+  end
+
+  def sponsored_credentials_template
+    YAML.load_file("config/#{ENV['RACK_ENV']}.yml").fetch("notify_email_template_ids").fetch("sponsored_credentials")
   end
 end

--- a/spec/lib/wifi_user/use_cases/check_user_is_sponsee_spec.rb
+++ b/spec/lib/wifi_user/use_cases/check_user_is_sponsee_spec.rb
@@ -1,0 +1,34 @@
+describe WifiUser::UseCase::CheckUserIsSponsee do
+  subject { described_class.new(allowlist_checker:) }
+
+  let(:allowlist_checker) { double(execute: { success: true }) }
+  let!(:sponsored_user) { FactoryBot.create(:user_details, :recent, :active, :sponsored) }
+
+  before do
+    @contact = sponsored_user.contact
+    @sponsor = sponsored_user.sponsor
+  end
+
+  context "given user is sponsored" do
+    it "returns true when sponsee has a valid sponsor email" do
+      result = subject.execute(sponsored_user.contact)
+      expect(result).to eq(true)
+    end
+
+    context "Invalid sponsor email" do
+      let(:allowlist_checker) { double(execute: { success: false }) }
+
+      it "returns false when sponsee has an invalid sponsor email" do
+        result = subject.execute(sponsored_user.contact)
+        expect(result).to eq(false)
+      end
+    end
+  end
+
+  context "given user does not have an account" do
+    it "returns false when user cannot be found in database" do
+      result = subject.execute("does_not_exist@example.com")
+      expect(result).to eq(false)
+    end
+  end
+end

--- a/spec/lib/wifi_user/use_cases/check_user_is_sponsee_spec.rb
+++ b/spec/lib/wifi_user/use_cases/check_user_is_sponsee_spec.rb
@@ -1,27 +1,25 @@
 describe WifiUser::UseCase::CheckUserIsSponsee do
-  subject { described_class.new(allowlist_checker:) }
+  subject { described_class.new }
 
-  let(:allowlist_checker) { double(execute: { success: true }) }
-  let!(:sponsored_user) { FactoryBot.create(:user_details, :recent, :active, :sponsored) }
+  let(:normal_user) { FactoryBot.create(:user_details, :recent, :active, :self_signed) }
+  let(:sponsee_user) { FactoryBot.create(:user_details, :recent, :active, :sponsored) }
 
   before do
-    @contact = sponsored_user.contact
-    @sponsor = sponsored_user.sponsor
+    @normal_user_contact = normal_user.contact
+    @sponsee_contact = sponsee_user.contact
   end
 
   context "given user is sponsored" do
     it "returns true when sponsee has a valid sponsor email" do
-      result = subject.execute(sponsored_user.contact)
+      result = subject.execute(@sponsee_contact)
       expect(result).to eq(true)
     end
+  end
 
-    context "Invalid sponsor email" do
-      let(:allowlist_checker) { double(execute: { success: false }) }
-
-      it "returns false when sponsee has an invalid sponsor email" do
-        result = subject.execute(sponsored_user.contact)
-        expect(result).to eq(false)
-      end
+  context "given user is not a sponsored" do
+    it "returns false when user's contact email provided matches their sponsor email" do
+      result = subject.execute(@normal_user_contact)
+      expect(result).to eq(false)
     end
   end
 


### PR DESCRIPTION
…up@wifi.service.gov.uk'

Sponsored Users could not get reminder of credentials when they email 'signup@wifi.service.gov.uk'. This commit adds a check to see if the Sponsee's Sponsor email address is valid, If so, we will send the normal email reminder of credentials normal.

### What
Describe the change
Given a Sponsee sends a blank email to 'signup@wifi.service.gov.uk'.
This PR checks the Sponsee's email address exists and their Sponsor email is valid.
If so, then the Sponsee will receive normal credentials reminder

### Why
Describe why the change was necessary
This fix is necessary because Sponsored Users were told they should email 'signup@wifi.service.gov.uk'
in-order to get reminder of their credentials, but Sponsee User receives not response.

Link to Trello card (if applicable):

https://technologyprogramme.atlassian.net/browse/GW-647
