### PR TITLE
Remove old concourse deployment references in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,7 @@ Then access the site at <http://localhost:8080/healthcheck>
 
 ### Deploying changes
 
-Once you have merged your changes into master branch, deploying them is made up of
-two steps:
-
-- Pushing a built image to the docker registry.
-
-- Restarting the running tasks so it picks up the latest image.
+You can find in depth instructions on using our deploy process [here](https://docs.google.com/document/d/1ORrF2HwrqUu3tPswSlB0Duvbi3YHzvESwOqEY9-w6IQ/) (you must be member of the GovWifi Team to access this document).
 
 ## Licence
 


### PR DESCRIPTION
### What
Remove old concourse deployment references in documentation. Add link to new deploy process

### Why
Keeping documentation up to date

Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-618


