### PR TITLE
Ensure the s3 region is correct and consistent

### DIFF
--- a/lib/common/gateway/s3_object_fetcher.rb
+++ b/lib/common/gateway/s3_object_fetcher.rb
@@ -8,7 +8,7 @@ class Common::Gateway::S3ObjectFetcher
   end
 
   def fetch
-    s3 = Aws::S3::Resource.new(client: Services.s3_client, region:)
+    s3 = Aws::S3::Resource.new(client: Services.s3_client(region:), region:)
     object = s3.bucket(bucket).object(key)
     object.get.body.read
   end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,6 +1,6 @@
 class Services
-  def self.s3_client
-    Aws::S3::Client.new(region: "eu-west-2")
+  def self.s3_client(region: "eu-west-2")
+    Aws::S3::Client.new(region:)
   end
 
   def self.notify_client

--- a/lib/wifi_user/use_case/sns_notification_handler.rb
+++ b/lib/wifi_user/use_case/sns_notification_handler.rb
@@ -55,6 +55,7 @@ private
     email_fetcher = Common::Gateway::S3ObjectFetcher.new(
       bucket: payload.fetch(:s3_bucket_name),
       key: payload.fetch(:s3_object_key),
+      region: "eu-west-1",
     )
     sponsee_extractor = WifiUser::UseCase::EmailSponseesExtractor.new(
       email_fetcher:,

--- a/spec/acceptance/email_notification_spec.rb
+++ b/spec/acceptance/email_notification_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe App do
       it "constructs Common::Gateway::S3ObjectFetcher with the bucket and keyName" do
         post_notification
         expect(Common::Gateway::S3ObjectFetcher).to have_received(:new)
-                                    .with(bucket: bucket_name, key: object_key)
+                                    .with(bucket: bucket_name, key: object_key, region: "eu-west-1")
       end
 
       it "constructs WifiUser::UseCase::EmailSponseesExtractor with the Common::Gateway::S3ObjectFetcher" do


### PR DESCRIPTION
### What
The S3 client was always instantiated with eu-west-2, but sometimes the resource was instantiated with eu-west-1. This commit makes these two the same value
### Why
This causes confusion and is the source of a possible issue
