### PR TITLE
Require 'yaml' library to fix issue in active user survey

### DIFF
--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,4 +1,5 @@
 require "sequel"
+require "yaml"
 
 if %w[production staging].include?(ENV["RACK_ENV"])
   require "raven"


### PR DESCRIPTION
The active user survey fails because it hasn't loaded the yaml library.

https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-1116