### PR TITLE
Change the time do delete inactive users from 24 to 12 months

### DIFF
--- a/lib/gdpr/gateway/user_details.rb
+++ b/lib/gdpr/gateway/user_details.rb
@@ -9,8 +9,8 @@ class Gdpr::Gateway::Userdetails
     total = 0
     loop do
       deleted_rows = DB[:userdetails].with_sql_delete("
-        DELETE FROM userdetails WHERE (last_login < DATE_SUB(NOW(), INTERVAL 24 MONTH)
-        OR (last_login IS NULL AND created_at < DATE_SUB(NOW(), INTERVAL 24 MONTH)))
+        DELETE FROM userdetails WHERE (last_login < DATE_SUB(NOW(), INTERVAL 12 MONTH)
+        OR (last_login IS NULL AND created_at < DATE_SUB(NOW(), INTERVAL 12 MONTH)))
         AND username != 'HEALTH'
         LIMIT #{SESSION_BATCH_SIZE}")
       total += deleted_rows

--- a/spec/lib/gdpr/gateway/user_details_spec.rb
+++ b/spec/lib/gdpr/gateway/user_details_spec.rb
@@ -8,7 +8,7 @@ describe Gdpr::Gateway::Userdetails do
       context "Given no inactive users" do
         before do
           user_details.insert(username: "bob", last_login: Date.today)
-          user_details.insert(username: "sally", last_login: Date.today - 729)
+          user_details.insert(username: "sally", last_login: Date.today - 363)
         end
 
         it "does not delete any users" do
@@ -19,8 +19,8 @@ describe Gdpr::Gateway::Userdetails do
       context "Given one inactive user" do
         before do
           user_details.insert(username: "bob", last_login: Date.today)
-          user_details.insert(username: "sally", created_at: Date.today - 729)
-          user_details.insert(username: "george", last_login: Date.today - 731)
+          user_details.insert(username: "sally", created_at: Date.today - 363)
+          user_details.insert(username: "george", last_login: Date.today - 367)
         end
 
         it "does deletes only the old user record" do
@@ -31,8 +31,8 @@ describe Gdpr::Gateway::Userdetails do
 
       context "Given multiple inactive user" do
         before do
-          user_details.insert(username: "bob", last_login: Date.today - 831)
-          user_details.insert(username: "george", last_login: Date.today - 731)
+          user_details.insert(username: "bob", last_login: Date.today - 367)
+          user_details.insert(username: "george", last_login: Date.today - 367)
         end
 
         it "deletes all the inactive users" do
@@ -59,7 +59,7 @@ describe Gdpr::Gateway::Userdetails do
       context "Given no inactive users" do
         before do
           user_details.insert(username: "bob", created_at: Date.today)
-          user_details.insert(username: "sally", created_at: Date.today - 729)
+          user_details.insert(username: "sally", created_at: Date.today - 300)
         end
 
         it "does not delete any user details" do
@@ -70,8 +70,8 @@ describe Gdpr::Gateway::Userdetails do
       context "Given one inactive user" do
         before do
           user_details.insert(username: "bob", created_at: Date.today)
-          user_details.insert(username: "sally", created_at: Date.today - 729)
-          user_details.insert(username: "george", created_at: Date.today - 731)
+          user_details.insert(username: "sally", created_at: Date.today - 300)
+          user_details.insert(username: "george", created_at: Date.today - 368)
         end
 
         it "does deletes only the old user record" do
@@ -82,8 +82,8 @@ describe Gdpr::Gateway::Userdetails do
 
       context "Given multiple inactive user" do
         before do
-          user_details.insert(username: "bob", created_at: Date.today - 831)
-          user_details.insert(username: "george", created_at: Date.today - 731)
+          user_details.insert(username: "bob", created_at: Date.today - 370)
+          user_details.insert(username: "george", created_at: Date.today - 380)
         end
 
         it "deletes all the inactive users" do


### PR DESCRIPTION
Currently we delete users who have been inactive for 24 months. We will change this to 12 months to stay in line with our GDPR commitments.

Jira: https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-692