### PR TITLE
Set the default value for the set_followup_sent_at attribute

### DIFF
--- a/mysql/migrations/20240625150300_init_followup_sent_at.rb
+++ b/mysql/migrations/20240625150300_init_followup_sent_at.rb
@@ -1,0 +1,7 @@
+require "sequel"
+
+Sequel.migration do
+  change do
+    Sequel::Model(:userdetails)["UPDATE userdetails SET followup_sent_at = '2000-01-01' where last_login IS NULL"]
+  end
+end


### PR DESCRIPTION
### What
Initialise the set_followup_sent_at attribute
### Why
So that we don't send followups to people that signed up a long time ago

Link to Trello card (if applicable): 
