### PR TITLE
Gw 587 reply to sponsors who use an unrecognised email do

### DIFF
--- a/config/alpaca.yml
+++ b/config/alpaca.yml
@@ -16,6 +16,7 @@ notify_sms_template_ids:
 
 notify_email_template_ids:
   self_signup_credentials: e67776c1-7ac4-43b1-b5fb-09aae69a5405
+  sponsor_rejection: 17119b7d-d72c-49db-b770-20f4c25c379f
   rejected_email_address: dabb9566-ae35-4ada-a9c5-2dd0db099539
   sponsored_credentials: 18aac792-fd98-4d96-884c-2179bdc2a76f
   sponsor_confirmation:

--- a/config/production.yml
+++ b/config/production.yml
@@ -20,6 +20,7 @@ notify_email_template_ids:
   self_signup_credentials: f18708c0-e857-4f62-b5f3-8f0c75fc2fdb
   rejected_email_address: 66a2be00-8398-43bc-b952-96c97420f6cf
   sponsored_credentials: fd536b81-bdd7-4b55-98aa-720173718642
+  sponsor_rejection: 17119b7d-d72c-49db-b770-20f4c25c379f
   sponsor_confirmation:
     plural: 58e8ef4a-ca6b-40cd-81df-ec9c781fed56
     singular: 30ab6bc5-20bf-45af-b78d-34cacc0027cd

--- a/config/staging.yml
+++ b/config/staging.yml
@@ -17,6 +17,7 @@ notify_sms_template_ids:
 
 notify_email_template_ids:
   self_signup_credentials: 96d1f5ac-2ebe-41a7-878f-9a569e0bb55c
+  sponsor_rejection: 17119b7d-d72c-49db-b770-20f4c25c379f
   rejected_email_address:  dabb9566-ae35-4ada-a9c5-2dd0db099539
   sponsored_credentials: 4f6bae31-5add-43a9-b0e3-7db43452676e
   sponsor_confirmation:

--- a/config/test.yml
+++ b/config/test.yml
@@ -15,6 +15,7 @@ notify_sms_template_ids:
 
 notify_email_template_ids:
   self_signup_credentials: email_self_signup_credentials_template_id
+  sponsor_rejection: 17119b7d-d72c-49db-b770-20f4c25c379f
   rejected_email_address: email_rejected_email_address_template_id
   sponsored_credentials: email_sponsored_credentials_template_id
   sponsor_confirmation:

--- a/lib/wifi_user/email_sender.rb
+++ b/lib/wifi_user/email_sender.rb
@@ -25,6 +25,14 @@ class WifiUser::EmailSender
     )
   end
 
+  def self.send_sponsor_rejection_email(sponsor_address)
+    Services.notify_client.send_email(
+      email_address: sponsor_address,
+      template_id: sponsor_rejection_email_template_id,
+      email_reply_to_id: do_not_reply_email_address_id,
+    )
+  end
+
   def self.send_sponsor_confirmation_plural(sponsor_address, sponsee_users)
     Services.notify_client.send_email(
       email_address: sponsor_address,
@@ -101,6 +109,10 @@ class WifiUser::EmailSender
 
   def self.sponsor_email_template_id
     YAML.load_file("config/#{ENV['RACK_ENV']}.yml").fetch("notify_email_template_ids").fetch("sponsored_credentials")
+  end
+
+  def self.sponsor_rejection_email_template_id
+    YAML.load_file("config/#{ENV['RACK_ENV']}.yml").fetch("notify_email_template_ids").fetch("sponsor_rejection")
   end
 
   def self.credentials_template_id


### PR DESCRIPTION
### What

You can sponsor a person to get GovWifi credentials. However you must email us from an ‘approved’ email domain. We don't respond to invalid emails.

### Why

If the email in invalid we should tell them there’s a problem. 




Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-587