### PR TITLE
exclude images from the email extractor

### DIFF
--- a/lib/wifi_user/use_case/email_sponsees_extractor.rb
+++ b/lib/wifi_user/use_case/email_sponsees_extractor.rb
@@ -44,7 +44,7 @@ private
   end
 
   def lines_from_html(html_part)
-    Nokogiri::HTML(html_part.decoded).xpath("//text()[not(ancestor::style)]").map do |node|
+    Nokogiri::HTML(html_part.decoded).xpath("//text()[not(ancestor::style) and not(ancestor::img)]").map do |node|
       node.xpath("normalize-space()")
     end
   end

--- a/spec/lib/wifi_user/use_cases/email_sponsees_extractor_spec.rb
+++ b/spec/lib/wifi_user/use_cases/email_sponsees_extractor_spec.rb
@@ -52,6 +52,11 @@ describe WifiUser::UseCase::EmailSponseesExtractor do
     expect(sponsees).to eq(["dan@example.com"])
   end
 
+  it "Ignores <img> tags and extracts visible text" do
+    write_email_to_s3(html_part: "<body><img src='image.jpg' alt='image'/><p>image@example.com</p></body>", bucket_name:, object_key:)
+    expect(sponsees).to eq(["image@example.com"])
+  end
+
   it "Returns empty array from an email with invalid HTML" do
     write_email_to_s3(html_part: "<body><asd", bucket_name:, object_key:)
     expect(sponsees).to eq([])


### PR DESCRIPTION
What
Email extractor picking up images

Why
Remove images from the email extractor

Link to Trello card (if applicable):