### PR TITLE
hotfix: update notify template id's

### DIFF
--- a/config/alpaca.yml
+++ b/config/alpaca.yml
@@ -16,7 +16,7 @@ notify_sms_template_ids:
 
 notify_email_template_ids:
   self_signup_credentials: e67776c1-7ac4-43b1-b5fb-09aae69a5405
-  sponsor_rejection: 17119b7d-d72c-49db-b770-20f4c25c379f
+  sponsor_rejection: 8504d92b-9275-4857-a04e-046df0cd874a
   rejected_email_address: dabb9566-ae35-4ada-a9c5-2dd0db099539
   sponsored_credentials: 18aac792-fd98-4d96-884c-2179bdc2a76f
   sponsor_confirmation:


### PR DESCRIPTION
HOTFIX: Update notify template id.

### What
There is a new ID for notify templates for rejected emails, but these templates were not created on Dev or Staging thus the build is failing.

### Why
So we can get the smoke tests to pass.