### PR TITLE
hotfix/add-update-template-ids

### DIFF
--- a/config/alpaca.yml
+++ b/config/alpaca.yml
@@ -20,9 +20,9 @@ notify_email_template_ids:
   rejected_email_address: dabb9566-ae35-4ada-a9c5-2dd0db099539
   sponsored_credentials: 18aac792-fd98-4d96-884c-2179bdc2a76f
   sponsor_confirmation:
-    plural: 856a5726-1099-4236-b67c-23b654e9edbf
-    singular: 079cb5ff-19b7-4a90-b2e8-dad342ca2bf9
-    failed: 3b1e71a6-a9be-4ba9-8598-44f4c6de340c
+    plural: 0f5d2b80-bcb4-4b38-beea-0268745429f5
+    singular: 67e4f3bb-e209-4697-8e93-f76dbd2e5047
+    failed: 8bd29338-f269-4724-acdb-dc369769104b
   active_users_signup_survey: 9cdaccbe-4813-4874-a4d7-172ebab5a927
   credentials_expiring_notification: 1b9aea55-02f6-4076-9745-24ff733ce4cd
   notify_user_account_removed: b0234d7-ede5-4593-bd10-fee9269fa656


### PR DESCRIPTION
### What
Add the new sponsor template id's (and actually templates in notify) 

### Why
causing smoke tests to fail.

Can we **please** remember to ensure **all** work is deployed to DEV and not just deployed to staging, this is causing a lot of time loss.



