### PR TITLE
Notify error should raise an error to be captured by Sentry

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -55,7 +55,6 @@ class App < Sinatra::Base
     raise
   rescue StandardError => e
     logger.warn(e.message)
-  ensure
     halt 200, ""
   end
 

--- a/spec/features/email_journey_spec.rb
+++ b/spec/features/email_journey_spec.rb
@@ -64,6 +64,15 @@ RSpec.describe App do
       end
     end
 
+    describe "Notify throws an error" do
+      before :each do
+        allow(Services.notify_client).to receive(:send_email).and_raise(Notifications::Client::BadRequestError.new(double(body: "Error", code: 400)))
+      end
+      it "re-raises the error" do
+        expect { do_user_signup }.to raise_error(Notifications::Client::BadRequestError)
+      end
+    end
+
     describe "the user already exists" do
       let(:from) { "john@gov.uk" }
       before :each do


### PR DESCRIPTION
The `ensure` statement meant the error was never raised and sent to Sentry