### PR TITLE
Introduce a custom error class to capture application specific errors

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -39,7 +39,7 @@ class App < Sinatra::Base
   end
 
   post "/user-signup/email-notification" do
-    raise "Unexpected request: \n #{request.body.read}" if request_invalid?(request)
+    raise UserSignupError, "Unexpected request: \n #{request.body.read}" if request_invalid?(request)
 
     sns_message = WifiUser::SnsMessage.new(body: request.body.read)
 
@@ -51,12 +51,12 @@ class App < Sinatra::Base
     else
       WifiUser::UseCase::EmailJourneyHandler.new(from_address: sns_message.from_address).execute
     end
-  rescue Notifications::Client::RequestError => e
-    logger.error(e.message)
-    raise
-  rescue StandardError => e
+  rescue UserSignupError => e
     logger.warn(e.message)
     halt 200, ""
+  rescue StandardError => e
+    logger.error(e.message)
+    raise
   end
 
   post "/user-signup/sms-notification/notify" do

--- a/lib/notifications/notify_templates.rb
+++ b/lib/notifications/notify_templates.rb
@@ -41,7 +41,7 @@ module Notifications
     def self.verify_templates
       names = Services.notify_client.get_all_templates.collection.map(&:name)
       differences = Notifications::NotifyTemplates::TEMPLATES - names
-      raise "Some templates have not been defined in Notify: #{differences.join(', ')}" unless differences.empty?
+      raise UserSignupError, "Some templates have not been defined in Notify: #{differences.join(', ')}" unless differences.empty?
     end
   end
 end

--- a/lib/user_signup_error.rb
+++ b/lib/user_signup_error.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class UserSignupError < StandardError
+end

--- a/lib/wifi_user/sns_message.rb
+++ b/lib/wifi_user/sns_message.rb
@@ -16,7 +16,7 @@ class WifiUser::SnsMessage
     @s3_object_key = parsed_message.fetch("receipt").fetch("action").fetch("objectKey")
     @s3_bucket_name = parsed_message.fetch("receipt").fetch("action").fetch("bucketName")
     @sponsor_request = Mail::Address.new(to_address).local == "sponsor"
-  rescue KeyError
-    raise "Unable to process signup. Malformed request: #{body}"
+  rescue StandardError
+    raise UserSignupError, "Unable to process signup. Malformed request: #{body}"
   end
 end

--- a/lib/wifi_user/use_case/email_sponsees_extractor.rb
+++ b/lib/wifi_user/use_case/email_sponsees_extractor.rb
@@ -12,7 +12,7 @@ class WifiUser::UseCase::EmailSponseesExtractor
     contacts = extract_contact_details_from lines_in_email
     remove_sponsor_from contacts
   rescue Mail::Field::ParseError => e
-    raise "unable to parse email address in #{@sns_message.parsed_message}: #{e}"
+    raise UserSignupError, "unable to parse email address in #{@sns_message.parsed_message}: #{e}"
   end
 
 private

--- a/lib/wifi_user/use_case/sponsor_journey_handler.rb
+++ b/lib/wifi_user/use_case/sponsor_journey_handler.rb
@@ -8,10 +8,10 @@ class WifiUser::UseCase::SponsorJourneyHandler
   def execute
     sponsor_address = @sns_message.from_address
     raw_sponsor_address = @sns_message.raw_from_address
-    raise "Unsuccessful sponsor signup attempt: #{sponsor_address}" if invalid_email?(sponsor_address)
+    raise UserSignupError, "Unsuccessful sponsor signup attempt: #{sponsor_address}" if invalid_email?(sponsor_address)
 
     sponsee_addresses = WifiUser::UseCase::EmailSponseesExtractor.new(sns_message: @sns_message).execute
-    raise "Unable to find sponsees: #{sponsor_address}" if sponsee_addresses.empty?
+    raise UserSignupError, "Unable to find sponsees: #{sponsor_address}" if sponsee_addresses.empty?
 
     sponsee_users = sponsee_addresses.map do |sponsee_address|
       WifiUser::User.find_or_create(contact: sponsee_address) { |user| user[:sponsor] = sponsor_address }

--- a/spec/lib/gdpr/gateway/user_details_spec.rb
+++ b/spec/lib/gdpr/gateway/user_details_spec.rb
@@ -83,7 +83,7 @@ describe Gdpr::Gateway::Userdetails do
 
       context "Sending an emails throws an exception" do
         before :each do
-          allow(Services.notify_client).to receive(:send_email).and_raise(StandardError)
+          allow(Services.notify_client).to receive(:send_email).and_raise(UserSignupError)
           user_details.insert(username: "george", contact: "george@gov.uk", last_login: Date.today - 367)
         end
         it "still deletes the user" do

--- a/spec/lib/notifications/notify_templates_spec.rb
+++ b/spec/lib/notifications/notify_templates_spec.rb
@@ -41,7 +41,7 @@ describe Notifications::NotifyTemplates do
 
       expect {
         Notifications::NotifyTemplates.verify_templates
-      }.to raise_error(/Some templates have not been defined in Notify: #{missing_template.name}/)
+      }.to raise_error(UserSignupError, /Some templates have not been defined in Notify: #{missing_template.name}/)
     end
   end
 end

--- a/spec/lib/survey/use_case/send_active_user_surveys_spec.rb
+++ b/spec/lib/survey/use_case/send_active_user_surveys_spec.rb
@@ -64,7 +64,7 @@ describe Survey::UseCase::SendActiveUserSurveys do
 
   context "Notify throws an error" do
     before :each do
-      allow(Services.notify_client).to receive(:send_email).and_raise(StandardError)
+      allow(Services.notify_client).to receive(:send_email).and_raise(UserSignupError)
       @user = FactoryBot.create(:user_details, created_at: yesterday)
     end
     it "logs the failure" do

--- a/spec/lib/wifi_user/use_cases/sponsor_journey_handler_spec.rb
+++ b/spec/lib/wifi_user/use_cases/sponsor_journey_handler_spec.rb
@@ -34,12 +34,12 @@ describe WifiUser::UseCase::SponsorJourneyHandler do
     it "raises an error" do
       expect {
         WifiUser::UseCase::SponsorJourneyHandler.new(sns_message:).execute
-      }.to raise_error(/Unsuccessful sponsor signup attempt/)
+      }.to raise_error(UserSignupError, /Unsuccessful sponsor signup attempt/)
     end
     it "does not create a new user" do
       expect {
         WifiUser::UseCase::SponsorJourneyHandler.new(sns_message:).execute
-      }.to raise_error.and change(WifiUser::User, :count).by(0)
+      }.to raise_error(UserSignupError).and change(WifiUser::User, :count).by(0)
     end
   end
 
@@ -50,12 +50,12 @@ describe WifiUser::UseCase::SponsorJourneyHandler do
     it "raises an error" do
       expect {
         WifiUser::UseCase::SponsorJourneyHandler.new(sns_message:).execute
-      }.to raise_error(/Unable to find sponsees:/)
+      }.to raise_error(UserSignupError, /Unable to find sponsees:/)
     end
     it "does not create a new user" do
       expect {
         WifiUser::UseCase::SponsorJourneyHandler.new(sns_message:).execute
-      }.to raise_error.and change(WifiUser::User, :count).by(0)
+      }.to raise_error(UserSignupError).and change(WifiUser::User, :count).by(0)
     end
   end
 


### PR DESCRIPTION
So that more errors are being sent to Sentry if something is to go wrong. Any expected errors caused by malformed user content being sent to the User signup API are caught using the UserSignupError class.

All other unspecified errors are now sent to Sentry to warn us about a potential issue in the code / enviromnent

### What
Describe the change

### Why
Describe why the change was necessary


Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251