### PR TITLE
Fix syntax on the migration

### DIFF
--- a/mysql/migrations/20240625150300_init_followup_sent_at.rb
+++ b/mysql/migrations/20240625150300_init_followup_sent_at.rb
@@ -2,6 +2,6 @@ require "sequel"
 
 Sequel.migration do
   change do
-    Sequel::Model(:userdetails)["UPDATE userdetails SET followup_sent_at = '2000-01-01' where last_login IS NULL"]
+    from(:userdetails).update(followup_sent_at: "2000-01-01")
   end
 end


### PR DESCRIPTION
This works - the previous form did not. Also, ensure all records have the follow_up_sent_at attribute set, which ensures none of the current users will be sent a follow-up message
