### PR TITLE
Use support reply id when sending followup emails

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       NOTIFY_API_KEY: dummy_key-00000000-0000-0000-0000-000000000000-00000000-0000-0000-0000-000000000000
       GOVNOTIFY_BEARER_TOKEN: 'dummy-bearer-token-1234'
       NOTIFY_DO_NOT_REPLY: 'do_not_reply_email_template_id'
+      NOTIFY_SUPPORT_REPLY: 'support_reply_email_template_id'
     expose:
         - "8080"
     volumes:

--- a/lib/wifi_user/email_sender.rb
+++ b/lib/wifi_user/email_sender.rb
@@ -63,7 +63,7 @@ class WifiUser::EmailSender
     Services.notify_client.send_email(
       email_address:,
       template_id: Notifications::NotifyTemplates.template(:followup_email),
-      email_reply_to_id: do_not_reply_email_address_id,
+      email_reply_to_id: support_reply_email_address_id,
     )
   end
 
@@ -99,5 +99,9 @@ class WifiUser::EmailSender
 
   def self.do_not_reply_email_address_id
     ENV["NOTIFY_DO_NOT_REPLY"] || "0d22d71f-afa3-4c72-8cd4-7716678dbd43"
+  end
+
+  def self.support_reply_email_address_id
+    ENV["NOTIFY_SUPPORT_REPLY"] || "5619b95b-2f93-4a70-be64-2f2568f8876f"
   end
 end

--- a/spec/lib/followups/followup_sender_spec.rb
+++ b/spec/lib/followups/followup_sender_spec.rb
@@ -62,7 +62,7 @@ describe Followups::FollowupSender do
       expect(notify_client).to have_received(:send_email).with(
         email_address: contact,
         template_id: "followup_email_id",
-        email_reply_to_id: "do_not_reply_email_template_id",
+        email_reply_to_id: "support_reply_email_template_id",
       )
     end
     it "does not send the emails twice" do


### PR DESCRIPTION
The followup email for inactive users should have the address of our support email inbox as a reply-to field so that users can contact us with their questions.