### PR TITLE
Revert "fix: [GW-2013] Update Ruby, Gems, Template, fix tests"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,5 +5,4 @@ Describe the change
 Describe why the change was necessary
 
 
-### Link to JIRA card (if applicable): 
-[GW-xxx](https://technologyprogramme.atlassian.net/browse/GW-xxx)
+Link to Trello card (if applicable): 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,15 +9,15 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
       - name: Run lint
         run: make lint
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
       - name: Run tests
         run: make test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitest (5.25.1)
-    mustermann (3.0.3)
+    mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     mysql2 (0.5.6)
     nenv (0.3.0)
@@ -107,12 +107,9 @@ GEM
     puma (6.4.3)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.8)
-    rack-protection (4.0.0)
-      base64 (>= 0.1.0)
-      rack (>= 3.0.0, < 4)
-    rack-session (2.0.0)
-      rack (>= 3.0.0)
+    rack (2.2.9)
+    rack-protection (3.0.2)
+      rack
     rack-test (2.1.0)
       rack (>= 1.3)
     rainbow (3.1.1)
@@ -184,14 +181,13 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sinatra (4.0.0)
+    sinatra (3.0.2)
       mustermann (~> 3.0)
-      rack (>= 3.0.0, < 4)
-      rack-protection (= 4.0.0)
-      rack-session (>= 2.0.0, < 3)
+      rack (~> 2.2, >= 2.2.4)
+      rack-protection (= 3.0.2)
       tilt (~> 2.0)
     thor (1.0.1)
-    tilt (2.4.0)
+    tilt (2.0.11)
     timecop (0.9.10)
     timeout (0.4.1)
     tzinfo (2.0.6)
@@ -233,4 +229,4 @@ RUBY VERSION
    ruby 3.3.5
 
 BUNDLED WITH
-   2.5.16
+   2.2.32

--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,4 @@ stop:
 	$(DOCKER_COMPOSE) kill
 	$(DOCKER_COMPOSE) rm -f
 
-update: stop
-	bundle lock --update
-	$(MAKE) build
-	$(MAKE) test
-
 .PHONY: test serve stop lint

--- a/app.rb
+++ b/app.rb
@@ -39,7 +39,6 @@ class App < Sinatra::Base
   end
 
   post "/user-signup/email-notification" do
-    request.body.rewind
     raise UserSignupError, "Unexpected request: \n #{request.body.read}" if request_invalid?(request)
 
     sns_message = WifiUser::SnsMessage.new(body: request.body.read)
@@ -61,7 +60,6 @@ class App < Sinatra::Base
   end
 
   post "/user-signup/sms-notification/notify" do
-    request.body.rewind
     halt(401, "") unless is_govnotify_token_valid?
 
     payload = JSON.parse(request.body.read)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require "simplecov"
 require "sequel"
 require "webmock/rspec"
 require "shared"
-require "ostruct"
+
 ENV["RACK_ENV"] = "test"
 
 require File.expand_path "../app.rb", __dir__


### PR DESCRIPTION
Reverts alphagov/govwifi-user-signup-api#869
Although this builds locally, and passes the github action, it's failing the ECS build with
```

November 19, 2024 at 12:20 (UTC) | bundler: command not found: rackup | 38ca80fb79804dfab30cf45b708f6109 | user-signup-api
-- | -- | -- | --
November 19, 2024 at 12:20 (UTC) | Install missing gem executables with `bundle install`
November 19, 2024 at 12:20 (UTC)
bundler: command not found: rackup
[38ca80fb79804dfab30cf45b708f6109](https://eu-west-2.console.aws.amazon.com/ecs/v2/clusters/alpaca-api-cluster/services/user-signup-api-service-alpaca/tasks/38ca80fb79804dfab30cf45b708f6109?region=eu-west-2)
user-signup-api
November 19, 2024 at 12:20 (UTC)
Install missing gem executables with `bundle install`
```
