### PR TITLE
Stop notifying users about GovWifi account deletion due to inactivity

### DIFF
--- a/lib/notifications/notify_templates.rb
+++ b/lib/notifications/notify_templates.rb
@@ -9,7 +9,6 @@ module Notifications
                    active_users_signup_survey_email
                    followup_email
                    credentials_expiring_notification_email
-                   user_account_removed_email
                    credentials_sms
                    recap_sms
                    help_menu_sms
@@ -21,9 +20,7 @@ module Notifications
                    device_help_blackberry_sms
                    device_help_chromebook_sms
                    active_users_signup_survey_sms
-                   followup_sms
-                   user_account_removed_sms
-                   credentials_expiring_notification_sms].freeze
+                   followup_sms].freeze
 
     def self.template_hash
       @template_hash ||= begin

--- a/lib/wifi_user/email_sender.rb
+++ b/lib/wifi_user/email_sender.rb
@@ -79,17 +79,6 @@ class WifiUser::EmailSender
     )
   end
 
-  def self.send_user_account_removed(_username, contact)
-    Services.notify_client.send_email(
-      email_address: contact,
-      template_id: Notifications::NotifyTemplates.template(:user_account_removed_email),
-      personalisation: {
-        inactivity_period: "12 months",
-      },
-      email_reply_to_id: do_not_reply_email_address_id,
-    )
-  end
-
   def self.send_active_users_signup_survey(user)
     Services.notify_client.send_email(
       email_address: user.contact,

--- a/lib/wifi_user/sms_sender.rb
+++ b/lib/wifi_user/sms_sender.rb
@@ -17,27 +17,6 @@ class WifiUser::SMSSender
     )
   end
 
-  def self.send_credentials_expiring_notification(username, contact)
-    Services.notify_client.send_sms(
-      phone_number: contact,
-      template_id: Notifications::NotifyTemplates.template(:credentials_expiring_notification_sms),
-      personalisation: {
-        username:,
-        inactivity_period: "11 months",
-      },
-    )
-  end
-
-  def self.send_user_account_removed(_username, contact)
-    Services.notify_client.send_sms(
-      phone_number: contact,
-      template_id: Notifications::NotifyTemplates.template(:user_account_removed_sms),
-      personalisation: {
-        inactivity_period: "12 months",
-      },
-    )
-  end
-
   def self.send_active_users_signup_survey(user)
     Services.notify_client.send_sms(
       phone_number: user.contact,


### PR DESCRIPTION
- Removed notifications informing users when their GovWifi account is deleted after 12 months of inactivity.

This decision was made because the emails have caused confusion among users, and it is unclear whether they provide any meaningful benefit.

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-2038
