### PR TITLE
replace alphagov org with govwifi in docs urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ This codebase is released under [the MIT License][mit].
 [mit]: LICENCE
 [performance-platform]: https://www.gov.uk/performance/govwifi
 [notify]: https://www.notifications.service.gov.uk/
-[build-repo]: https://github.com/alphagov/govwifi-build
+[build-repo]: https://github.com/GovWifi/govwifi-build


### PR DESCRIPTION
### What
Update our docs to reflect changes in GDS repos

### Why
We must keep our docs up to date and accurate

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?assignee=5b2a20739ba6d02662e2fc0b&selectedIssue=GW-2341