### PR TITLE
deduplicates duplicate email contacts

### DIFF
--- a/lib/wifi_user/use_case/sponsor_journey_handler.rb
+++ b/lib/wifi_user/use_case/sponsor_journey_handler.rb
@@ -11,7 +11,7 @@ class WifiUser::UseCase::SponsorJourneyHandler
     raw_sponsor_address = @sns_message.raw_from_address
     raise UserSignupError, "Unsuccessful sponsor signup attempt: #{sponsor_address}" if invalid_email?(sponsor_address)
 
-    sponsee_addresses = WifiUser::UseCase::EmailSponseesExtractor.new(sns_message: @sns_message).execute
+    sponsee_addresses = WifiUser::UseCase::EmailSponseesExtractor.new(sns_message: @sns_message).execute.uniq
     raise UserSignupError, "Unable to find sponsees: #{sponsor_address}" if sponsee_addresses.empty?
 
     sponsee_users = sponsee_addresses.map do |sponsee_address|

--- a/spec/features/sponsor_journey_spec.rb
+++ b/spec/features/sponsor_journey_spec.rb
@@ -134,6 +134,21 @@ RSpec.describe App do
         notify_has_sent_email_to "john@nongov.uk"
         notify_has_sent_email_to "emma@elsewhere.uk"
       end
+
+      it "deduplicates duplicate email contacts before sending credentials" do
+        write_email_to_s3(body: "john@nongov.uk\njohn@nongov.uk\nemma@elsewhere.uk", bucket_name:, object_key:)
+
+        expect {
+          do_user_signup
+        }.to change(WifiUser::User, :count).by(2)
+
+        expect(Services.notify_client).to have_received(:send_email).with(
+          hash_including(email_address: "john@nongov.uk", template_id: "sponsor_credentials_email_id"),
+        ).once
+        expect(Services.notify_client).to have_received(:send_email).with(
+          hash_including(email_address: "emma@elsewhere.uk", template_id: "sponsor_credentials_email_id"),
+        ).once
+      end
     end
 
     describe "A valid sponsor signs up users through SMS" do

--- a/spec/lib/wifi_user/use_cases/sponsor_journey_handler_spec.rb
+++ b/spec/lib/wifi_user/use_cases/sponsor_journey_handler_spec.rb
@@ -115,6 +115,22 @@ describe WifiUser::UseCase::SponsorJourneyHandler do
         email_reply_to_id: "do_not_reply_email_template_id",
       )
     end
+    context "the sponsor email includes duplicate contacts" do
+      before :each do
+        write_email_to_s3(body: "dave@nongov.uk\n07701001111\ndave@nongov.uk\n07701001111", bucket_name:, object_key:)
+      end
+
+      it "sends credentials once per unique contact" do
+        WifiUser::UseCase::SponsorJourneyHandler.new(sns_message:).execute
+
+        expect(notify_client).to have_received(:send_email).with(
+          hash_including(email_address: "dave@nongov.uk", template_id: "sponsor_credentials_email_id"),
+        ).once
+        expect(Services.notify_client).to have_received(:send_sms).with(
+          hash_including(phone_number: "+447701001111", template_id: "credentials_sms_id"),
+        ).once
+      end
+    end
     context "a user already exists but has not been sponsored" do
       before :each do
         @user = WifiUser::User.create(contact: "test@gov.uk")


### PR DESCRIPTION
### What
Deduplicates duplicate email contacts

### Why
Users sending bulk request often mistakingly add duplicates 

### Link to JIRA card (if applicable): 
[GW-xxx](https://technologyprogramme.atlassian.net/browse/GW-xxx)
https://technologyprogramme.atlassian.net/browse/GW-2736
