### PR TITLE
FIX: Dependabot - gem "net-imap", ">= 0.5.14"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     mysql2 (0.5.7)
       bigdecimal
     nenv (0.3.0)
-    net-imap (0.5.12)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)


### PR DESCRIPTION
### What
Several vulnerabilities in the net-imap gem have been discovered.
It is recommended to update to the latest version of this gem to fix these.

### Why
To prevent several high/moderate attack vectors based around escalation highjacking.

### Link to JIRA card (if applicable):
[Dependabot](https://github.com/GovWifi/govwifi-user-signup-api/security/dependabot)
